### PR TITLE
Improve desktop entry file

### DIFF
--- a/resources/desktop/rssguard.desktop
+++ b/resources/desktop/rssguard.desktop
@@ -1,14 +1,16 @@
 [Desktop Entry]
 Type=Application
 Version=1.0
-Encoding=UTF-8
 Exec=rssguard
 X-GNOME-Autostart-Delay=15
+X-LXQt-Need-Tray=true
 Name=RSS Guard
-GenericName=A (very) tiny feed reader
+GenericName=Feed reader
 GenericName[cs]=Velmi jednoduchá čtečka kanálů
-Comment=A (very) tiny feed reader
+GenericName[de]=Feedreader
+Comment=Tiny yet feature rich Qt feed reader
 Comment[cs]=Velmi jednoduchá čtečka kanálů
+Comment[de]=Qt Feedreader mit großem Funktionsumfang bei geringem Ressourcenbedarf
 Icon=rssguard
 Terminal=false
 Categories=Qt;Network;News;


### PR DESCRIPTION
This PR is proposing some changes in the desktop entry file.

*Encoding*
Removed as [deprecated](https://specifications.freedesktop.org/desktop-entry-spec/latest/apc.html) according to the specification.

*X-LXQt-Need-Tray=true*
This key makes RSS Guard start after the panel on LXQt if stated in the desktop entry file to auto start the application. This prevents a crash / core dump that reproducibly takes place otherwise when auto start is enabled and RSS Guard is configured to display the tray icon upon launch. It shouldn't do any harm as it's a custom key according to section [Extending the format](https://specifications.freedesktop.org/desktop-entry-spec/latest/ar01s11.html) of the underlying specification.

*GenericName*
The text is the same as in key `Comment` and rather matching the latter which doesn't make sense. Btw. this triggers a warning of tool `desktop-file-validate`, too, which will give trouble should this application get packaged by the major Linux distributions one day.
So the text was adjusted to match the key's purpose.

*Comment*
The current text is a bit misleading as it sounds like RSS Guard was just some minimal UI providing basic features only. But to me it rather seems like an application which offers quite a lot of features while still keeping the foot print rather small.
Text was changed to reflect this.