### PR TITLE
Don't show icons in menus on Mac

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -83,6 +83,9 @@ int main(int argc, char *argv[]) {
 
   QApplication::setAttribute(Qt::AA_UseHighDpiPixmaps);
   QApplication::setAttribute(Qt::AA_EnableHighDpiScaling);
+#ifdef Q_OS_MAC
+  QApplication::setAttribute(Qt::AA_DontShowIconsInMenus);
+#endif
 
   // Register needed metatypes.
   qRegisterMetaType<QList<Message> >("QList<Message>");


### PR DESCRIPTION
On macOS it is customary to not show any icons in menus.