### PR TITLE
Fix for three GUI issues on macOS

### DIFF
--- a/rssguard.pro
+++ b/rssguard.pro
@@ -459,8 +459,10 @@ SOURCES +=  src/core/feeddownloader.cpp \
             src/core/messagesmodelcache.cpp \
             src/core/messagesmodelsqllayer.cpp \
             src/gui/treeviewcolumnsmenu.cpp \
-    src/services/abstract/labelsrootitem.cpp \
-    src/services/abstract/label.cpp
+            src/services/abstract/labelsrootitem.cpp \
+            src/services/abstract/label.cpp
+
+OBJECTIVE_SOURCES += src/miscellaneous/disablewindowtabbing.mm
 
 FORMS +=    src/gui/toolbareditor.ui \
             src/network-web/downloaditem.ui \
@@ -763,6 +765,7 @@ mac {
   ICON = resources/macosx/$${TARGET}.icns
   QMAKE_MAC_SDK = macosx10.12
   QMAKE_MACOSX_DEPLOYMENT_TARGET = 10.7
+  LIBS += -framework AppKit
 
   target.path = $$quote($$PREFIX/Contents/MacOS/)
 

--- a/src/gui/dialogs/formmain.cpp
+++ b/src/gui/dialogs/formmain.cpp
@@ -138,7 +138,9 @@ QList<QAction*> FormMain::allActions() const {
   actions << m_ui->m_actionAboutGuard;
   actions << m_ui->m_actionSwitchFeedsList;
   actions << m_ui->m_actionSwitchMainWindow;
+#if !defined(Q_OS_MAC)
   actions << m_ui->m_actionSwitchMainMenu;
+#endif
   actions << m_ui->m_actionSwitchToolBars;
   actions << m_ui->m_actionSwitchListHeaders;
   actions << m_ui->m_actionSwitchStatusBar;
@@ -210,6 +212,10 @@ void FormMain::prepareMenus() {
 #if !defined(USE_WEBENGINE)
   m_ui->m_menuWebBrowserTabs->removeAction(m_ui->m_actionTabNewWebBrowser);
   m_ui->m_menuWebBrowserTabs->setTitle(tr("Tabs"));
+#endif
+
+#if defined(Q_OS_MAC)
+  m_ui->m_actionSwitchMainMenu->setVisible(false);
 #endif
 }
 

--- a/src/gui/dialogs/formmain.cpp
+++ b/src/gui/dialogs/formmain.cpp
@@ -134,7 +134,9 @@ QList<QAction*> FormMain::allActions() const {
   actions << m_ui->m_actionBackupDatabaseSettings;
   actions << m_ui->m_actionRestart;
   actions << m_ui->m_actionQuit;
+#if !defined(Q_OS_MAC)
   actions << m_ui->m_actionFullscreen;
+#endif
   actions << m_ui->m_actionAboutGuard;
   actions << m_ui->m_actionSwitchFeedsList;
   actions << m_ui->m_actionSwitchMainWindow;
@@ -216,6 +218,7 @@ void FormMain::prepareMenus() {
 
 #if defined(Q_OS_MAC)
   m_ui->m_actionSwitchMainMenu->setVisible(false);
+  m_ui->m_actionFullscreen->setVisible(false);
 #endif
 }
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -39,6 +39,7 @@
 #include <QDebug>
 #include <QTimer>
 
+extern void disableWindowTabbing();
 
 int main(int argc, char *argv[]) {
   for (int i = 0; i < argc; i++) {
@@ -85,6 +86,7 @@ int main(int argc, char *argv[]) {
   QApplication::setAttribute(Qt::AA_EnableHighDpiScaling);
 #ifdef Q_OS_MAC
   QApplication::setAttribute(Qt::AA_DontShowIconsInMenus);
+  disableWindowTabbing();
 #endif
 
   // Register needed metatypes.

--- a/src/miscellaneous/disablewindowtabbing.mm
+++ b/src/miscellaneous/disablewindowtabbing.mm
@@ -1,0 +1,11 @@
+
+#import <AppKit/AppKit.h>
+
+// Disables auto window tabbing where supported, otherwise a no-op.
+// See http://lists.qt-project.org/pipermail/interest/2016-September/024488.html
+void disableWindowTabbing()
+{
+    if ([NSWindow respondsToSelector:@selector(allowsAutomaticWindowTabbing)]) {
+        NSWindow.allowsAutomaticWindowTabbing = NO;
+    }
+}


### PR DESCRIPTION
- Disable native window tabbing on macOS. Otherwise macOS automatically adds an item on the View menu to show the system tab bar.
- Hide the menu item to show/hide the menu bar. It has no effect and meaning on macOS.
- Hide the menu item to view full screen. This is handled natively by macOS.