### PR TITLE
Add appstream metadata file

### DIFF
--- a/resources/desktop/rssguard.appdata.xml
+++ b/resources/desktop/rssguard.appdata.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="utf-8"?>
+<component type="desktop">
+    <id>org.rssguard.RSSGuard.desktop</id>
+    <metadata_license>CC0-1.0</metadata_license>
+    <project_license>GPL-3.0</project_license>
+    <name>RSS Guard</name>
+    <summary>Feed reader</summary>
+    <description>
+       <p>Tiny yet feature rich Qt feed reader.</p>
+    </description>
+    <categories>
+        <category>Network</category>
+        <category>News</category>
+    </categories>
+    <url type="homepage">https://github.com/martinrotter/rssguard/</url>
+    <url type="bugtracker">https://github.com/martinrotter/rssguard/issues</url>
+    <provides>
+        <binary>rssguard</binary>
+    </provides>
+</component>

--- a/resources/rssguard.qrc
+++ b/resources/rssguard.qrc
@@ -1554,6 +1554,7 @@
         <file>localizations/rssguard_pt.qm</file>
         <file>localizations/rssguard_sv.qm</file>
         <file>localizations/rssguard_zh.qm</file>
+        <file>desktop/rssguard.appdata.xml</file>
         <file>desktop/rssguard.desktop</file>
         <file>desktop/rssguard.desktop.autostart</file>
         <file>localizations/qt_bg.qm</file>

--- a/rssguard.pro
+++ b/rssguard.pro
@@ -671,13 +671,16 @@ win32 {
 unix:!mac:!android {
   target.path = $$PREFIX/bin
 
+  appdata_file.files = resources/desktop/$${TARGET}.appdata.xml
+  appdata_file.path = $$quote($$PREFIX/share/appdata/)
+
   desktop_file.files = resources/desktop/$${TARGET}.desktop
   desktop_file.path = $$quote($$PREFIX/share/applications/)
 
   desktop_icon.files = resources/graphics/$${TARGET}.png
   desktop_icon.path = $$quote($$PREFIX/share/pixmaps/)
 
-  INSTALLS += target desktop_file desktop_icon
+  INSTALLS += target appdata_file desktop_file desktop_icon
 }
 
 android {


### PR DESCRIPTION
Appstream metadata are used by Linux app software centers to list applications and information abou them. This way you can have RSS Guard listed e.g. by gnome-software or KDE Plasma Discover. I also need appstream metadata for this project to be able to package RSS Guard for Flatpak. 

PS: You can extend appstream metadata by other stuff, like with a link where you except donations or link with a screenshot.