### PR TITLE
Solution bug #172

### DIFF
--- a/src/services/tt-rss/network/ttrssnetworkfactory.cpp
+++ b/src/services/tt-rss/network/ttrssnetworkfactory.cpp
@@ -580,8 +580,9 @@ QList<Message> TtRssGetHeadlinesResponse::messages() const {
     message.m_contents = mapped["content"].toString();
 
     // Multiply by 1000 because Tiny Tiny RSS API does not include miliseconds in Unix
-    // date/time number.
-    message.m_created = TextFactory::parseDateTime(int(mapped["updated"].toDouble()) * 1000);
+    // date/time number. 
+    const qint64 t = static_cast<qint64>(mapped["updated"].toDouble()) * 1000;
+    message.m_created = TextFactory::parseDateTime(t);
     message.m_createdFromFeed = true;
     message.m_customId = QString::number(mapped["id"].toInt());
     message.m_feedId = mapped["feed_id"].toString();

--- a/src/services/tt-rss/network/ttrssnetworkfactory.cpp
+++ b/src/services/tt-rss/network/ttrssnetworkfactory.cpp
@@ -225,7 +225,7 @@ TtRssGetHeadlinesResponse TtRssNetworkFactory::getHeadlines(int feed_id, int lim
     result = TtRssGetHeadlinesResponse(QString::fromUtf8(result_raw));
   }
 
-  IOFactory::writeFile("aaa", result_raw);
+  //IOFactory::writeFile("aaa", result_raw);
 
   if (network_reply.first != QNetworkReply::NoError) {
     qWarning("TT-RSS: getHeadlines failed with error %d.", network_reply.first);


### PR DESCRIPTION
Hello,

I’ve fixed Bug #172 in the branch named “tt-rss/dateError” in my fork.
Unfortunately with this bug one can't use rssguard together with tiny tiny rss. I hope this will help to get rid of it.

Thanx