### PR TITLE
Added urls, oars, release info

### DIFF
--- a/resources/desktop/com.github.rssguard.appdata.xml
+++ b/resources/desktop/com.github.rssguard.appdata.xml
@@ -25,6 +25,26 @@
     </screenshot>
   </screenshots>
   <url type="homepage">https://github.com/martinrotter/rssguard</url>
+  <url type="bugtracker">https://github.com/martinrotter/rssguard/issues</url>
+  <url type="translate">https://www.transifex.com/martinrotter/rssguard/</url>
+  <url type="donation">https://martinrotter.github.io/donate/</url>
+  <content_rating type="oars-1.1" />
+  <releases>
+    <release version="3.5.6" date="2018-02-26">
+      <description>
+        <p>Fixed:</p>
+        <ul>
+          <li>Some minor stuff fixes.</li>
+          <li>Unnecessary "Welcome" notifications. (bug #176)</li>
+          <li>Bad handling of null/empty strings when inserting messages into DB. (bug #169)</li>
+          <li>Bad conversion of "created on" date/time in TT-RSS plugin. (bug #172)</li>
+          <li>Missing obligatory attribute in OPML 2.0 files. (bug #166)</li>
+        </ul>
+      </description>
+    </release>
+    <release version="3.5.5" date="2017-11-19"/>
+    <release version="3.5.4" date="2017-10-23"/>
+  </releases>
   <provides>
     <binary>rssguard</binary>
   </provides>


### PR DESCRIPTION
* Added URL for bugtracker, donation and translation
* Added support for OARS (age content rating)
* Added release information. Ideally this should be updated by adding a new `<release>` section every time there is a new release. The information will be presented in software centers (like GNOME Software and KDE Discover) and on Flathub. This lets users more easily learn about the latest development for their favorite apps, software centers also reward apps that provide this information by featuring them more prominently. 
Relevant AppStream documentation: https://www.freedesktop.org/software/appstream/docs/chap-Metadata.html#tag-releases