### PR TITLE
Install icons under icons/hicolor/scalable/apps instead of pixmaps

### DIFF
--- a/rssguard.pro
+++ b/rssguard.pro
@@ -686,7 +686,7 @@ unix:!mac:!android {
   appdata.path = $$quote($$PREFIX/share/metainfo/)
 
   desktop_icon.files = resources/graphics/$${TARGET}.png
-  desktop_icon.path = $$quote($$PREFIX/share/pixmaps/)
+  desktop_icon.path = $$quote($$PREFIX/share/icons/hicolor/512x512/apps/)
 
   INSTALLS += target desktop_file desktop_icon appdata
 }


### PR DESCRIPTION
This is the recommendation of the Icon Theme Specification:
https://standards.freedesktop.org/icon-theme-spec/icon-theme-spec-latest.html#install_icons