### PR TITLE
increase length of column Feeds.url in MySQL from 100 to 1000

### DIFF
--- a/resources/sql.qrc
+++ b/resources/sql.qrc
@@ -11,6 +11,7 @@
     <file>sql/db_update_mysql_8_9.sql</file>
     <file>sql/db_update_mysql_9_10.sql</file>
     <file>sql/db_update_mysql_10_11.sql</file>
+    <file>sql/db_update_mysql_11_12.sql</file>
 
     <file>sql/db_init_sqlite.sql</file>
     <file>sql/db_update_sqlite_1_2.sql</file>

--- a/resources/sql/db_update_mysql_11_12.sql
+++ b/resources/sql/db_update_mysql_11_12.sql
@@ -1,0 +1,3 @@
+ALTER TABLE Feeds
+MODIFY url  VARCHAR(1000);
+-- !


### PR DESCRIPTION
If Feed's URL is too long, user got error "Feed was not added due to error"