### PR TITLE
Fixes control reaches end of non-void function error

### DIFF
--- a/src/librssguard/miscellaneous/databasefactory.cpp
+++ b/src/librssguard/miscellaneous/databasefactory.cpp
@@ -464,6 +464,7 @@ QSqlDatabase DatabaseFactory::connection(const QString& connection_name, Desired
     case UsedDriver::SQLITE_MEMORY:
       return sqliteConnection(connection_name, desired_type);
   }
+  return connection("null", DesiredType::StrictlyInMemory);
 }
 
 QString DatabaseFactory::humanDriverName(DatabaseFactory::UsedDriver driver) const {


### PR DESCRIPTION
Trying to avoid that warning when building on OBS/openSUSE.
