### PR TITLE
linux: set StartupWMClass in desktop file

### DIFF
--- a/resources/desktop/com.github.rssguard.desktop
+++ b/resources/desktop/com.github.rssguard.desktop
@@ -14,3 +14,4 @@ Comment[de]=Qt Feedreader mit großem Funktionsumfang bei geringem Ressourcenbed
 Icon=rssguard
 Terminal=false
 Categories=Qt;Network;News;
+StartupWMClass=rssguard


### PR DESCRIPTION
Apparently, Qt applications running on GNOME will need this key set, otherwise you won't be able to add them to your Favorites.

A few Qt apps that have `StartupWMClass` set:

* [qBittorrent](https://github.com/qbittorrent/qBittorrent/commit/9ccb4e2781aeeb121e00f3591f640dbb0ca6488c)
* [KeePassXC](https://github.com/keepassxreboot/keepassxc/commit/afe2967473dd6b6e23b81b2dbbab7d5402f71a1b)

And here's the desktop specification: https://specifications.freedesktop.org/desktop-entry-spec/latest/ar01s06.html

Before (right clicking RSS Guard):

![image](https://user-images.githubusercontent.com/626206/105566894-4fd13200-5d0d-11eb-9f66-b577bd6eef11.png)

After:

![image](https://user-images.githubusercontent.com/626206/105566903-64adc580-5d0d-11eb-98aa-4a5796b85529.png)
