### PR TITLE
configure icon/skin themes early in startup

### DIFF
--- a/src/librssguard/miscellaneous/application.cpp
+++ b/src/librssguard/miscellaneous/application.cpp
@@ -81,6 +81,12 @@ Application::Application(const QString& id, int& argc, char** argv)
   //: Name of translator - optional.
   QObject::tr("LANG_AUTHOR");
 
+  // Add an extra path for non-system icon themes and set current icon theme
+  // and skin.
+  m_icons->setupSearchPaths();
+  m_icons->loadCurrentIconTheme();
+  m_skins->loadCurrentSkin();
+
   connect(this, &Application::aboutToQuit, this, &Application::onAboutToQuit);
   connect(this, &Application::commitDataRequest, this, &Application::onCommitData);
   connect(this, &Application::saveStateRequest, this, &Application::onSaveState);

--- a/src/rssguard/main.cpp
+++ b/src/rssguard/main.cpp
@@ -74,12 +74,6 @@ int main(int argc, char* argv[]) {
   qRegisterMetaType<QList<Label*>>("QList<Label*>");
   qRegisterMetaType<Label*>("Label*");
 
-  // Add an extra path for non-system icon themes and set current icon theme
-  // and skin.
-  qApp->icons()->setupSearchPaths();
-  qApp->icons()->loadCurrentIconTheme();
-  qApp->skins()->loadCurrentSkin();
-
   // These settings needs to be set before any QSettings object.
   Application::setApplicationName(QSL(APP_NAME));
   Application::setApplicationVersion(QSL(APP_VERSION));


### PR DESCRIPTION
After changing the icon theme some of the icons were still from my
current system (Gentoo/KDE) icon theme. Moving the theme setup
earlier in the startup fixed it.