### PR TITLE
Allow force dark look for qt6ct

### DIFF
--- a/src/librssguard/miscellaneous/skinfactory.cpp
+++ b/src/librssguard/miscellaneous/skinfactory.cpp
@@ -45,7 +45,7 @@ void SkinFactory::loadCurrentSkin() {
 }
 
 bool SkinFactory::isStyleGoodForDarkVariant(const QString& style_name) const {
-  return QRegularExpression("^(fusion)|(qt5ct-style)$").match(style_name.toLower()).hasMatch();
+  return QRegularExpression("^(fusion)|(qt5ct-style)|(qt6ct-style)$").match(style_name.toLower()).hasMatch();
 }
 
 void SkinFactory::loadSkinFromData(const Skin& skin) {

--- a/src/librssguard/miscellaneous/skinfactory.cpp
+++ b/src/librssguard/miscellaneous/skinfactory.cpp
@@ -45,7 +45,7 @@ void SkinFactory::loadCurrentSkin() {
 }
 
 bool SkinFactory::isStyleGoodForDarkVariant(const QString& style_name) const {
-  return QRegularExpression("^(fusion)|(qt5ct-style)|(qt6ct-style)$").match(style_name.toLower()).hasMatch();
+  return QRegularExpression("^(fusion)|(qt[56]ct-style)$").match(style_name.toLower()).hasMatch();
 }
 
 void SkinFactory::loadSkinFromData(const Skin& skin) {


### PR DESCRIPTION
Since qt6ct can act as the middleman between Qt Fusion and RSS Guard, too.