### PR TITLE
Hide URL if `href` attribute is empty (nudus skins)

### DIFF
--- a/resources/skins/nudus-base/html_style_base.scss
+++ b/resources/skins/nudus-base/html_style_base.scss
@@ -346,10 +346,10 @@ summary {
 }
 
 // m* == message*
-body:hover .rssguard-mwrapper .rssguard-mhead .mwrapurl {
+body:hover .rssguard-mwrapper .rssguard-mhead .mwrapurl a {
 
-    a,
-    span {
+    &,
+    &:not([href=""]) + span { // NOTE: 'a[href="*"] + span' is never visible
         visibility: visible;
     }
 }
@@ -396,6 +396,14 @@ body:hover .rssguard-mwrapper .rssguard-mhead .mwrapurl {
                 a,
                 span {
                     visibility: hidden;
+                }
+
+                a[href=""] {
+
+                    &,
+                    & + span {
+                        display: none;
+                    }
                 }
             }
         }

--- a/resources/skins/nudus-dark/html_style.css
+++ b/resources/skins/nudus-dark/html_style.css
@@ -293,8 +293,7 @@ summary:focus {
   outline: 1px solid #8291AD;
 }
 
-body:hover .rssguard-mwrapper .rssguard-mhead .mwrapurl a,
-body:hover .rssguard-mwrapper .rssguard-mhead .mwrapurl span {
+body:hover .rssguard-mwrapper .rssguard-mhead .mwrapurl a, body:hover .rssguard-mwrapper .rssguard-mhead .mwrapurl a:not([href=""]) + span {
   visibility: visible;
 }
 
@@ -327,6 +326,9 @@ body:hover .rssguard-mwrapper .rssguard-mhead .mwrapurl span {
 .rssguard-mwrapper .rssguard-mhead .mlinks .mwrapurl a,
 .rssguard-mwrapper .rssguard-mhead .mlinks .mwrapurl span {
   visibility: hidden;
+}
+.rssguard-mwrapper .rssguard-mhead .mlinks .mwrapurl a[href=""], .rssguard-mwrapper .rssguard-mhead .mlinks .mwrapurl a[href=""] + span {
+  display: none;
 }
 .rssguard-mwrapper .rssguard-mbody img {
   max-width: 450px !important;

--- a/resources/skins/nudus-dark/metadata.xml
+++ b/resources/skins/nudus-dark/metadata.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<skin version="0.1" base="nudus-base">
+<skin version="0.1.1" base="nudus-base">
   <author>
     <name>akinokonomi</name>
   </author>

--- a/resources/skins/nudus-light/html_style.css
+++ b/resources/skins/nudus-light/html_style.css
@@ -293,8 +293,7 @@ summary:focus {
   outline: 1px solid #5D88D2;
 }
 
-body:hover .rssguard-mwrapper .rssguard-mhead .mwrapurl a,
-body:hover .rssguard-mwrapper .rssguard-mhead .mwrapurl span {
+body:hover .rssguard-mwrapper .rssguard-mhead .mwrapurl a, body:hover .rssguard-mwrapper .rssguard-mhead .mwrapurl a:not([href=""]) + span {
   visibility: visible;
 }
 
@@ -327,6 +326,9 @@ body:hover .rssguard-mwrapper .rssguard-mhead .mwrapurl span {
 .rssguard-mwrapper .rssguard-mhead .mlinks .mwrapurl a,
 .rssguard-mwrapper .rssguard-mhead .mlinks .mwrapurl span {
   visibility: hidden;
+}
+.rssguard-mwrapper .rssguard-mhead .mlinks .mwrapurl a[href=""], .rssguard-mwrapper .rssguard-mhead .mlinks .mwrapurl a[href=""] + span {
+  display: none;
 }
 .rssguard-mwrapper .rssguard-mbody img {
   max-width: 450px !important;

--- a/resources/skins/nudus-light/metadata.xml
+++ b/resources/skins/nudus-light/metadata.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<skin version="0.1" base="nudus-base">
+<skin version="0.1.1" base="nudus-base">
   <author>
     <name>akinokonomi</name>
   </author>


### PR DESCRIPTION
With this commit, if feed's article link is empty (`<link href="" />`), the URL element in article browser won't be displayed.

Feed example:
```xml
<?xml version="1.0" encoding="UTF-8" ?>
<feed xmlns="http://www.w3.org/2005/Atom">
...
    <entry>
        <title type="html">Title</title>
        <link href="" />
        <updated>2022-01-01T00:00:00+00:00</updated>
        <id>id</id>
        <summary type="html">
            summary
        </summary>
    </entry>
</feed>
```