### PR TITLE
Use system default monospace font for code elements (nudus skins)

### DIFF
--- a/resources/skins/nudus-base/html_style_base.scss
+++ b/resources/skins/nudus-base/html_style_base.scss
@@ -18,11 +18,9 @@ $base-unit:     10px !default;
 //
 
 // Let the font be customised via RSS Guard settings
-// Note: Font size there related **only** to that font alone, it is
-// not absolute, and nothing else can be done from my side
-// E.g. "Roboto 10" <-- something like this is send from RSS Guard side
 * {
     font-family: inherit;
+    font-size: inherit;
 }
 
 //
@@ -182,7 +180,11 @@ code {
     border: 1px solid $cbor3;
     border-radius: $radius-unit;
     color: $cfg10;
-    // cursor: text;
+    //cursor: text;
+
+    // Font for code blocks falls back to system default monospace
+    font-family: monospace;
+    font-size: .95rem !important;
 }
 
 code {
@@ -349,11 +351,12 @@ summary {
 body:hover .rssguard-mwrapper .rssguard-mhead .mwrapurl a {
 
     &,
-    &:not([href=""]) + span { // NOTE: 'a[href="*"] + span' is never visible
+    &:not([href=""]) + span {
         visibility: visible;
     }
 }
 
+// Stay visible when right-clicked
 .rssguard-mwrapper .rssguard-mhead .mwrapurl a:focus {
 
     &,

--- a/resources/skins/nudus-dark/html_style.css
+++ b/resources/skins/nudus-dark/html_style.css
@@ -1,6 +1,7 @@
 @charset "UTF-8";
 * {
   font-family: inherit;
+  font-size: inherit;
 }
 
 body, h1, h2, h3, h4, h5, h6,
@@ -162,6 +163,8 @@ code {
   border: 1px solid #282a2c;
   border-radius: 0.3em;
   color: #D8D8D8;
+  font-family: monospace;
+  font-size: .95rem !important;
 }
 
 code {

--- a/resources/skins/nudus-light/html_style.css
+++ b/resources/skins/nudus-light/html_style.css
@@ -1,6 +1,7 @@
 @charset "UTF-8";
 * {
   font-family: inherit;
+  font-size: inherit;
 }
 
 body, h1, h2, h3, h4, h5, h6,
@@ -162,6 +163,8 @@ code {
   border: 1px solid #DEDEDE;
   border-radius: 0.1em;
   color: #343434;
+  font-family: monospace;
+  font-size: .95rem !important;
 }
 
 code {


### PR DESCRIPTION
With this PR, `<pre>` and `<code>` elements in article browser will use system default monospace font. 

(Not tested on Windows.)