### PR TITLE
Fix build issue in newsblur when compiling with GCC 11.2

### DIFF
--- a/src/librssguard/services/newsblur/newsblurnetwork.cpp
+++ b/src/librssguard/services/newsblur/newsblurnetwork.cpp
@@ -203,7 +203,7 @@ void NewsBlurNetwork::setBatchSize(int batch_size) {
 }
 
 void NewsBlurNetwork::clearCredentials() {
-  m_authSid = {};
+  m_authSid = QString{};
   m_userId = {};
 }
 


### PR DESCRIPTION
GCC thinks the assignment is ambiguous