### PR TITLE
Add option to control the display of the unread message count on task bar

### DIFF
--- a/src/librssguard/gui/settings/settingsgui.cpp
+++ b/src/librssguard/gui/settings/settingsgui.cpp
@@ -34,6 +34,10 @@ SettingsGui::SettingsGui(Settings* settings, QWidget* parent) : SettingsPanel(se
                                      << /*: Version column of skin list. */ tr("Version")
                                      << tr("Author"));
 
+#if !defined(Q_OS_UNIX) || defined(Q_OS_MACOS)
+  m_ui->m_tabUi->setTabVisible(m_ui->m_tabUi->indexOf(m_ui->m_taskBar), false);
+#endif
+
   m_ui->m_helpCustomSkinColors->setHelpText(tr("You can override some colors defined by your skin here. "
                                                "Some colors are used dynamically throughout the application."), false);
 
@@ -73,6 +77,7 @@ SettingsGui::SettingsGui(Settings* settings, QWidget* parent) : SettingsPanel(se
           &QStackedWidget::setCurrentIndex);
   connect(m_ui->m_gbCustomSkinColors, &QGroupBox::toggled, this, &SettingsGui::dirtifySettings);
   connect(m_ui->m_spinToolbarIconSize, QOverload<int>::of(&QSpinBox::valueChanged), this, &SettingsGui::dirtifySettings);
+  connect(m_ui->m_displayUnreadMessageCountOnTaskBar, &QCheckBox::toggled, this, &SettingsGui::dirtifySettings);
 
   connect(m_ui->m_spinToolbarIconSize, QOverload<int>::of(&QSpinBox::valueChanged), this, [=](int value) {
     if (value <= 0) {
@@ -145,6 +150,10 @@ void SettingsGui::loadSettings() {
 
   m_ui->m_checkMonochromeIcons->setChecked(settings()->value(GROUP(GUI), SETTING(GUI::MonochromeTrayIcon)).toBool());
   m_ui->m_checkCountUnreadMessages->setChecked(settings()->value(GROUP(GUI), SETTING(GUI::UnreadNumbersInTrayIcon)).toBool());
+
+#if defined(Q_OS_UNIX) && !defined(Q_OS_MACOS)
+  m_ui->m_displayUnreadMessageCountOnTaskBar->setChecked(settings()->value(GROUP(GUI), SETTING(GUI::UnreadNumbersOnTaskBar)).toBool());
+#endif
 
   // Mark active theme.
   if (current_theme == QL1S(APP_NO_THEME)) {
@@ -325,6 +334,10 @@ void SettingsGui::saveSettings() {
   settings()->setValue(GROUP(GUI), GUI::HideMainWindowWhenMinimized, m_ui->m_checkHideWhenMinimized->isChecked());
 
   settings()->setValue(GROUP(GUI), GUI::ForceDarkFusion, m_ui->m_checkForceDarkFusion->isChecked());
+
+#if defined(Q_OS_UNIX) && !defined(Q_OS_MACOS)
+  settings()->setValue(GROUP(GUI), GUI::UnreadNumbersOnTaskBar, m_ui->m_displayUnreadMessageCountOnTaskBar->isChecked());
+#endif
 
   // Make sure that number of unread messages is shown in tray icon as requested.
   qApp->feedReader()->feedsModel()->notifyWithCounts();

--- a/src/librssguard/gui/settings/settingsgui.ui
+++ b/src/librssguard/gui/settings/settingsgui.ui
@@ -410,6 +410,24 @@
        </item>
       </layout>
      </widget>
+     <widget class="QWidget" name="m_taskBar">
+      <attribute name="title">
+       <string>Task bar</string>
+      </attribute>
+      <widget class="QCheckBox" name="m_displayUnreadMessageCountOnTaskBar">
+       <property name="geometry">
+        <rect>
+         <x>10</x>
+         <y>10</y>
+         <width>321</width>
+         <height>25</height>
+        </rect>
+       </property>
+       <property name="text">
+        <string>Display count of unread messages</string>
+       </property>
+      </widget>
+     </widget>
     </widget>
    </item>
   </layout>

--- a/src/librssguard/miscellaneous/application.cpp
+++ b/src/librssguard/miscellaneous/application.cpp
@@ -643,7 +643,9 @@ void Application::showMessagesNumber(int unread_messages, bool any_feed_has_unre
   QVariantMap setProperty;
 
   setProperty.insert("count", qint64(unread_messages));
-  setProperty.insert("count-visible", unread_messages > 0);
+  bool task_bar_count_enabled = settings()->value(GROUP(GUI),
+                                                  SETTING(GUI::UnreadNumbersOnTaskBar)).toBool();
+  setProperty.insert("count-visible", task_bar_count_enabled && unread_messages > 0);
 
   signal << setProperty;
 

--- a/src/librssguard/miscellaneous/settings.cpp
+++ b/src/librssguard/miscellaneous/settings.cpp
@@ -260,6 +260,11 @@ DVALUE(bool) GUI::ForceDarkFusionDef = false;
 DKEY GUI::UnreadNumbersInTrayIcon = "show_unread_numbers_in_tray_icon";
 DVALUE(bool) GUI::UnreadNumbersInTrayIconDef = true;
 
+#if defined(Q_OS_UNIX) && !defined(Q_OS_MACOS)
+DKEY GUI::UnreadNumbersOnTaskBar = "show_unread_numbers_on_task_bar";
+DVALUE(bool) GUI::UnreadNumbersOnTaskBarDef = true;
+#endif
+
 DKEY GUI::UseTrayIcon = "use_tray_icon";
 DVALUE(bool) GUI::UseTrayIconDef = true;
 

--- a/src/librssguard/miscellaneous/settings.h
+++ b/src/librssguard/miscellaneous/settings.h
@@ -267,6 +267,11 @@ namespace GUI {
   KEY UnreadNumbersInTrayIcon;
   VALUE(bool) UnreadNumbersInTrayIconDef;
 
+#if defined(Q_OS_UNIX) && !defined(Q_OS_MACOS)
+  KEY UnreadNumbersOnTaskBar;
+  VALUE(bool) UnreadNumbersOnTaskBarDef;
+#endif
+
   KEY TabCloseMiddleClick;
   VALUE(bool) TabCloseMiddleClickDef;
 


### PR DESCRIPTION
In a news reading style with many sources and leaving messages unread
the unread message count becomes irrelevant. We already have an option
to disable the count in the icon tray, but not on the task bar. Added a
checkbox to enable/disable the message count on apps task bar icon /
entry.

Chose to put it into a new tab page as we might add more task bar
functionality (progress update, recent articles, etc..).