### PR TITLE
[WORKAROUND] Use WebEngine cookie storage to avoid `::fdatasync`

### DIFF
--- a/src/librssguard/network-web/cookiejar.cpp
+++ b/src/librssguard/network-web/cookiejar.cpp
@@ -113,7 +113,6 @@ bool CookieJar::insertCookieInternal(const QNetworkCookie& cookie, bool should_s
 #if defined(USE_WEBENGINE)
     m_webEngineCookies->setCookie(cookie);
 #else
-    Q_UNUSED(notify_others)
     if (should_save) {
       saveCookies();
     }
@@ -131,7 +130,6 @@ bool CookieJar::updateCookieInternal(const QNetworkCookie& cookie) {
 #if defined(USE_WEBENGINE)
     m_webEngineCookies->setCookie(cookie);
 #else
-    Q_UNUSED(notify_others)
     saveCookies();
 #endif
   }
@@ -146,7 +144,6 @@ bool CookieJar::deleteCookieInternal(const QNetworkCookie& cookie) {
 #if defined(USE_WEBENGINE)
     m_webEngineCookies->deleteCookie(cookie);
 #else
-    Q_UNUSED(notify_others)
     saveCookies();
 #endif
   }

--- a/src/librssguard/network-web/cookiejar.cpp
+++ b/src/librssguard/network-web/cookiejar.cpp
@@ -20,17 +20,8 @@
 
 CookieJar::CookieJar(QObject* parent) : QNetworkCookieJar(parent) {
 #if defined(USE_WEBENGINE)
-  QWebEngineProfile::defaultProfile()->setPersistentCookiesPolicy(QWebEngineProfile::PersistentCookiesPolicy::NoPersistentCookies);
-
+  QWebEngineProfile::defaultProfile()->setPersistentCookiesPolicy(QWebEngineProfile::PersistentCookiesPolicy::AllowPersistentCookies);
   m_webEngineCookies = QWebEngineProfile::defaultProfile()->cookieStore();
-
-  // When cookies change in WebEngine, then change in main cookie jar too.
-  connect(m_webEngineCookies, &QWebEngineCookieStore::cookieAdded, this, [=](const QNetworkCookie& cookie) {
-    insertCookieInternal(cookie, false, true);
-  });
-  connect(m_webEngineCookies, &QWebEngineCookieStore::cookieRemoved, this, [=](const QNetworkCookie& cookie) {
-    deleteCookieInternal(cookie, false);
-  });
 #endif
 
   loadCookies();
@@ -75,7 +66,7 @@ void CookieJar::loadCookies() {
       auto cookie = QNetworkCookie::parseCookies(encoded);
 
       if (!cookie.isEmpty()) {
-        if (!insertCookieInternal(cookie.at(0), true, false)) {
+        if (!insertCookieInternal(cookie.at(0), false)) {
           qCriticalNN << LOGSEC_NETWORK
                       << "Failed to load cookie"
                       << QUOTE_W_SPACE(cookie_key)
@@ -115,56 +106,48 @@ bool CookieJar::setCookiesFromUrl(const QList<QNetworkCookie>& cookie_list, cons
   return QNetworkCookieJar::setCookiesFromUrl(cookie_list, url);
 }
 
-bool CookieJar::insertCookieInternal(const QNetworkCookie& cookie, bool notify_others, bool should_save) {
+bool CookieJar::insertCookieInternal(const QNetworkCookie& cookie, bool should_save) {
   auto result = QNetworkCookieJar::insertCookie(cookie);
 
   if (result) {
+#if defined(USE_WEBENGINE)
+    m_webEngineCookies->setCookie(cookie);
+#else
+    Q_UNUSED(notify_others)
     if (should_save) {
       saveCookies();
     }
-
-#if defined(USE_WEBENGINE)
-    if (notify_others) {
-      //m_webEngineCookies->setCookie(cookie);
-    }
-#else
-    Q_UNUSED(notify_others)
 #endif
   }
 
   return result;
 }
 
-bool CookieJar::updateCookieInternal(const QNetworkCookie& cookie, bool notify_others) {
+bool CookieJar::updateCookieInternal(const QNetworkCookie& cookie) {
   auto result = QNetworkCookieJar::updateCookie(cookie);
 
   if (result) {
-    saveCookies();
 
 #if defined(USE_WEBENGINE)
-    if (notify_others) {
-      //m_webEngineCookies->setCookie(cookie);
-    }
+    m_webEngineCookies->setCookie(cookie);
 #else
     Q_UNUSED(notify_others)
+    saveCookies();
 #endif
   }
 
   return result;
 }
 
-bool CookieJar::deleteCookieInternal(const QNetworkCookie& cookie, bool notify_others) {
+bool CookieJar::deleteCookieInternal(const QNetworkCookie& cookie) {
   auto result = QNetworkCookieJar::deleteCookie(cookie);
 
   if (result) {
-    saveCookies();
-
 #if defined(USE_WEBENGINE)
-    if (notify_others) {
-      //m_webEngineCookies->deleteCookie(cookie);
-    }
+    m_webEngineCookies->deleteCookie(cookie);
 #else
     Q_UNUSED(notify_others)
+    saveCookies();
 #endif
   }
 
@@ -172,13 +155,13 @@ bool CookieJar::deleteCookieInternal(const QNetworkCookie& cookie, bool notify_o
 }
 
 bool CookieJar::insertCookie(const QNetworkCookie& cookie) {
-  return insertCookieInternal(cookie, true, true);
+  return insertCookieInternal(cookie, true);
 }
 
 bool CookieJar::deleteCookie(const QNetworkCookie& cookie) {
-  return deleteCookieInternal(cookie, true);
+  return deleteCookieInternal(cookie);
 }
 
 bool CookieJar::updateCookie(const QNetworkCookie& cookie) {
-  return updateCookieInternal(cookie, true);
+  return updateCookieInternal(cookie);
 }

--- a/src/librssguard/network-web/cookiejar.h
+++ b/src/librssguard/network-web/cookiejar.h
@@ -23,9 +23,9 @@ class CookieJar : public QNetworkCookieJar {
     static QList<QNetworkCookie> extractCookiesFromUrl(const QString& url);
 
   private:
-    bool insertCookieInternal(const QNetworkCookie& cookie, bool notify_others, bool should_save);
-    bool updateCookieInternal(const QNetworkCookie& cookie, bool notify_others);
-    bool deleteCookieInternal(const QNetworkCookie& cookie, bool notify_others);
+    bool insertCookieInternal(const QNetworkCookie& cookie, bool should_save);
+    bool updateCookieInternal(const QNetworkCookie& cookie);
+    bool deleteCookieInternal(const QNetworkCookie& cookie);
 
     void loadCookies();
     void saveCookies();


### PR DESCRIPTION
It appears that using `QSetting` to store cookies leads to frequent
disk cache flushes as `QSattings::setPassword` unconditionally calls
`::fdatasync` on Linux. This may negatively impact performance, and
cause additional wear on SSDs.

This PR is not meant to be the solution but my current workaround,
and I'd like to work out a proper approach.