### PR TITLE
Modify min Qt version of Qt5 in CMakeLists

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -29,7 +29,7 @@
 #
 # Other information:
 #   - supports Windows, Linux, *BSD, macOS, OS/2, Android,
-#   - Qt 5.10.0 or newer is required,
+#   - Qt 5.12.0 or newer is required,
 #   - Qt 6.2.3 or newer is required,
 #   - cmake 3.9.0 or newer is required,
 #   - if you wish to make packages for Windows, then you must initialize all submodules
@@ -112,7 +112,7 @@ option(REVISION_FROM_GIT "Get revision using `git rev-parse`" ON)
 
 # Import Qt libraries.
 set(QT6_MIN_VERSION 6.2.3)
-set(QT5_MIN_VERSION 5.10.0)
+set(QT5_MIN_VERSION 5.12.0)
 
 set(QT_COMPONENTS
   Core


### PR DESCRIPTION
In the file "filteringexception.h" use the enum "QJSValue::ErrorType",but this enum define in Qt 5.12
![image](https://user-images.githubusercontent.com/60250462/159893428-4b7ac71f-aa43-4512-b01f-585c50382ffb.png)
