### PR TITLE
Never hide article URL (nudus skins)

### DIFF
--- a/resources/skins/nudus-base/html_single_message.html
+++ b/resources/skins/nudus-base/html_single_message.html
@@ -3,7 +3,7 @@
 <section class="rssguard-mhead">
     <div style="float: right; margin: 10px;"><!-- Should it remain here??? -->%7</div>
     <span class="msmall">%2</span>
-    <h1>%1<span class="mlinks">%6<span class="mwrapurl"><a href="%3">URL</a><span>&nbsp;&#47;&nbsp;</span></span></h1>
+    <h1>%1<span class="mlinks">%6<span class="mwrapurl"><span>&nbsp;&#47;&nbsp;</span><a href="%3">URL</a></span></h1>
     <span class="msmall">%5</span>
 </section>
 

--- a/resources/skins/nudus-base/html_style_base.scss
+++ b/resources/skins/nudus-base/html_style_base.scss
@@ -348,23 +348,6 @@ summary {
 }
 
 // m* == message*
-html:hover .rssguard-mwrapper .rssguard-mhead .mwrapurl a {
-
-    &,
-    &:not([href=""]) + span {
-        visibility: visible;
-    }
-}
-
-// Stay visible when right-clicked
-.rssguard-mwrapper .rssguard-mhead .mwrapurl a:focus {
-
-    &,
-    & + span {
-        visibility: visible !important;
-    }
-}
-
 .rssguard-mwrapper {
     padding: $base-unit !important;
 
@@ -391,15 +374,6 @@ html:hover .rssguard-mwrapper .rssguard-mhead .mwrapurl a {
 
             .mwrapurl {
                 display: inline-flex;
-
-                a {
-                    order: 1;
-                }
-
-                a,
-                span {
-                    visibility: hidden;
-                }
 
                 a[href=""] {
 

--- a/resources/skins/nudus-base/html_style_base.scss
+++ b/resources/skins/nudus-base/html_style_base.scss
@@ -348,7 +348,7 @@ summary {
 }
 
 // m* == message*
-body:hover .rssguard-mwrapper .rssguard-mhead .mwrapurl a {
+html:hover .rssguard-mwrapper .rssguard-mhead .mwrapurl a {
 
     &,
     &:not([href=""]) + span {

--- a/resources/skins/nudus-dark/html_style.css
+++ b/resources/skins/nudus-dark/html_style.css
@@ -296,7 +296,7 @@ summary:focus {
   outline: 1px solid #8291AD;
 }
 
-body:hover .rssguard-mwrapper .rssguard-mhead .mwrapurl a, body:hover .rssguard-mwrapper .rssguard-mhead .mwrapurl a:not([href=""]) + span {
+html:hover .rssguard-mwrapper .rssguard-mhead .mwrapurl a, html:hover .rssguard-mwrapper .rssguard-mhead .mwrapurl a:not([href=""]) + span {
   visibility: visible;
 }
 

--- a/resources/skins/nudus-dark/html_style.css
+++ b/resources/skins/nudus-dark/html_style.css
@@ -296,14 +296,6 @@ summary:focus {
   outline: 1px solid #8291AD;
 }
 
-html:hover .rssguard-mwrapper .rssguard-mhead .mwrapurl a, html:hover .rssguard-mwrapper .rssguard-mhead .mwrapurl a:not([href=""]) + span {
-  visibility: visible;
-}
-
-.rssguard-mwrapper .rssguard-mhead .mwrapurl a:focus, .rssguard-mwrapper .rssguard-mhead .mwrapurl a:focus + span {
-  visibility: visible !important;
-}
-
 .rssguard-mwrapper {
   padding: 10px !important;
 }
@@ -322,13 +314,6 @@ html:hover .rssguard-mwrapper .rssguard-mhead .mwrapurl a, html:hover .rssguard-
 }
 .rssguard-mwrapper .rssguard-mhead .mlinks .mwrapurl {
   display: inline-flex;
-}
-.rssguard-mwrapper .rssguard-mhead .mlinks .mwrapurl a {
-  order: 1;
-}
-.rssguard-mwrapper .rssguard-mhead .mlinks .mwrapurl a,
-.rssguard-mwrapper .rssguard-mhead .mlinks .mwrapurl span {
-  visibility: hidden;
 }
 .rssguard-mwrapper .rssguard-mhead .mlinks .mwrapurl a[href=""], .rssguard-mwrapper .rssguard-mhead .mlinks .mwrapurl a[href=""] + span {
   display: none;

--- a/resources/skins/nudus-dark/metadata.xml
+++ b/resources/skins/nudus-dark/metadata.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<skin version="0.1.3" base="nudus-base">
+<skin version="0.1.4" base="nudus-base">
   <author>
     <name>akinokonomi, martinrotter</name>
   </author>

--- a/resources/skins/nudus-light/html_style.css
+++ b/resources/skins/nudus-light/html_style.css
@@ -296,7 +296,7 @@ summary:focus {
   outline: 1px solid #5D88D2;
 }
 
-body:hover .rssguard-mwrapper .rssguard-mhead .mwrapurl a, body:hover .rssguard-mwrapper .rssguard-mhead .mwrapurl a:not([href=""]) + span {
+html:hover .rssguard-mwrapper .rssguard-mhead .mwrapurl a, html:hover .rssguard-mwrapper .rssguard-mhead .mwrapurl a:not([href=""]) + span {
   visibility: visible;
 }
 

--- a/resources/skins/nudus-light/html_style.css
+++ b/resources/skins/nudus-light/html_style.css
@@ -296,14 +296,6 @@ summary:focus {
   outline: 1px solid #5D88D2;
 }
 
-html:hover .rssguard-mwrapper .rssguard-mhead .mwrapurl a, html:hover .rssguard-mwrapper .rssguard-mhead .mwrapurl a:not([href=""]) + span {
-  visibility: visible;
-}
-
-.rssguard-mwrapper .rssguard-mhead .mwrapurl a:focus, .rssguard-mwrapper .rssguard-mhead .mwrapurl a:focus + span {
-  visibility: visible !important;
-}
-
 .rssguard-mwrapper {
   padding: 10px !important;
 }
@@ -322,13 +314,6 @@ html:hover .rssguard-mwrapper .rssguard-mhead .mwrapurl a, html:hover .rssguard-
 }
 .rssguard-mwrapper .rssguard-mhead .mlinks .mwrapurl {
   display: inline-flex;
-}
-.rssguard-mwrapper .rssguard-mhead .mlinks .mwrapurl a {
-  order: 1;
-}
-.rssguard-mwrapper .rssguard-mhead .mlinks .mwrapurl a,
-.rssguard-mwrapper .rssguard-mhead .mlinks .mwrapurl span {
-  visibility: hidden;
 }
 .rssguard-mwrapper .rssguard-mhead .mlinks .mwrapurl a[href=""], .rssguard-mwrapper .rssguard-mhead .mlinks .mwrapurl a[href=""] + span {
   display: none;

--- a/resources/skins/nudus-light/metadata.xml
+++ b/resources/skins/nudus-light/metadata.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<skin version="0.1.3" base="nudus-base">
+<skin version="0.1.4" base="nudus-base">
   <author>
     <name>akinokonomi, martinrotter</name>
   </author>


### PR DESCRIPTION
EDIT: I decided to make it as a single PR.

First commit is just for history's sake. It fixes the problem when "URL" becomes invisible when window scrollbar is hovered.

In second commit this feature is removed entirely.

@martinrotter, Merge them as **two** separate commits. It would not make sense otherwise.  
I repeat, **Do not squash them.** Please. 

Thanks.