### PR TITLE
Use the direct URL for the screenshot

### DIFF
--- a/resources/desktop/com.github.rssguard.appdata.xml
+++ b/resources/desktop/com.github.rssguard.appdata.xml
@@ -16,7 +16,7 @@
   <launchable type="desktop-id">com.github.rssguard.desktop</launchable>
   <screenshots>
   <screenshot type="default">
-      <image>https://github.com/martinrotter/rssguard/blob/master/resources/docs/images/rssguard-window.png?raw=true</image>
+      <image>https://raw.githubusercontent.com/martinrotter/rssguard/master/resources/docs/images/rssguard-window.png</image>
     </screenshot>
   </screenshots>
   <url type="homepage">https://github.com/martinrotter/rssguard</url>


### PR DESCRIPTION
Should probably fix Flathub not being able to download the screenshot and leaving an empty space instead of the screenshot:

![image](https://user-images.githubusercontent.com/626206/193379205-336b4f35-1b0f-4943-b7d0-094fdd875e37.png)
