### PR TITLE
Processing of mediaThumbnail and mediaDescription for Nextcloud feeds

### DIFF
--- a/src/librssguard/services/owncloud/owncloudnetworkfactory.cpp
+++ b/src/librssguard/services/owncloud/owncloudnetworkfactory.cpp
@@ -587,13 +587,13 @@ QList<Message> OwnCloudGetMessagesResponse::messages() const {
     msg.m_customHash = message_map[QSL("guidHash")].toString();
     msg.m_rawContents = QJsonDocument(message_map).toJson(QJsonDocument::JsonFormat::Compact);
 
-    //In case body is empty, check for content in mediaDescription if item is available
-    if(msg.m_contents.isEmpty() && !message_map[QSL("mediaDescription")].isUndefined()){
+    // In case body is empty, check for content in mediaDescription if item is available.
+    if (msg.m_contents.isEmpty() && !message_map[QSL("mediaDescription")].isUndefined()) {
       msg.m_contents = message_map[QSL("mediaDescription")].toString();
     }
 
-    //Check for mediaThumbnail and append as first enclosure to be viewed in internal viewer
-    if(!message_map[QSL("mediaThumbnail")].isUndefined()){
+    // Check for mediaThumbnail and append as first enclosure to be viewed in internal viewer.
+    if (!message_map[QSL("mediaThumbnail")].isUndefined()) {
       Enclosure enclosure;
 
       enclosure.m_mimeType = QSL("image/jpg");

--- a/src/librssguard/services/owncloud/owncloudnetworkfactory.cpp
+++ b/src/librssguard/services/owncloud/owncloudnetworkfactory.cpp
@@ -587,6 +587,21 @@ QList<Message> OwnCloudGetMessagesResponse::messages() const {
     msg.m_customHash = message_map[QSL("guidHash")].toString();
     msg.m_rawContents = QJsonDocument(message_map).toJson(QJsonDocument::JsonFormat::Compact);
 
+    //In case body is empty, check for content in mediaDescription if item is available
+    if(msg.m_contents.isEmpty() && !message_map[QSL("mediaDescription")].isUndefined()){
+      msg.m_contents = message_map[QSL("mediaDescription")].toString();
+    }
+
+    //Check for mediaThumbnail and append as first enclosure to be viewed in internal viewer
+    if(!message_map[QSL("mediaThumbnail")].isUndefined()){
+      Enclosure enclosure;
+
+      enclosure.m_mimeType = QSL("image/jpg");
+      enclosure.m_url = message_map[QSL("mediaThumbnail")].toString();
+
+      msg.m_enclosures.append(enclosure);
+    }
+
     QString enclosure_link = message_map[QSL("enclosureLink")].toString();
 
     if (!enclosure_link.isEmpty()) {


### PR DESCRIPTION
Processing of mediaThumbnail item as first enclosure and mediaDescription item as replacement content in Nextcloud feeds.

When subscribing to a Youtube channel using Nextcloud News, RSS Guard internal viewer would show no video description or thumbnail. 

This is due to the feed containing all information in the mediaThumbnail and mediaDescription, e.g. see https://www.youtube.com/feeds/videos.xml?channel_id=UCu7_D0o48KbfhpEohoP7YSQ

By processing these items the internal viewer can show all relevant information. (Limit for picture height increased to 300px in RSS Guard settings.)

New:
![New](https://user-images.githubusercontent.com/43409436/199226726-81349746-8915-473c-b6e7-e87559ed090a.png)

Previous:
![Previous](https://user-images.githubusercontent.com/43409436/199226730-3a4a425d-81d2-49c2-8ba4-dcd0b63d8c4c.png)
