### PR TITLE
Avoid empty png enclosure in YouTube feeds with Nextcloud

### DIFF
--- a/src/librssguard/services/owncloud/owncloudnetworkfactory.cpp
+++ b/src/librssguard/services/owncloud/owncloudnetworkfactory.cpp
@@ -614,7 +614,9 @@ QList<Message> OwnCloudGetMessagesResponse::messages() const {
         enclosure.m_mimeType = QSL("image/png");
       }
 
-      msg.m_enclosures.append(enclosure);
+      if (!message_map[QSL("enclosureMime")].toString().isEmpty() || !enclosure_link.startsWith(QSL("https://www.youtube.com/v/"))) {
+        msg.m_enclosures.append(enclosure);
+      }
     }
 
     msg.m_feedId = message_map[QSL("feedId")].toVariant().toString();


### PR DESCRIPTION
Check if enclosureLink starts with https://www.youtube.com/v/ if enclosureMime is empty. Avoid appending an empty png enclosure. 

Removes the empty png in internal viewer. Also the thumbnail would jump to the left in the internal viewer, because the "image/png" would load with a latency, even when cycling through the feed entries. 

This time, I tried to follow ClangFormat and hope I got it right.

Previous:
![Previous](https://user-images.githubusercontent.com/43409436/199939825-3712ef9f-c250-4b72-9613-2cf42dfba54b.png)

New: 
![New](https://user-images.githubusercontent.com/43409436/199939886-8ceb8546-e554-4ed5-8be0-920027289166.png)
