### PR TITLE
Update new color keys in metadata.xml (nudus skins)

### DIFF
--- a/resources/skins/nudus-dark/html_style.css
+++ b/resources/skins/nudus-dark/html_style.css
@@ -155,14 +155,14 @@ blockquote {
 }
 blockquote,
 blockquote p {
-  color: #D8D8D8;
+  color: #E2E2E2;
 }
 
 pre,
 code {
   border: 1px solid #282a2c;
   border-radius: 0.3em;
-  color: #D8D8D8;
+  color: #E2E2E2;
   font-family: monospace;
   font-size: .95rem !important;
 }

--- a/resources/skins/nudus-dark/html_style.css
+++ b/resources/skins/nudus-dark/html_style.css
@@ -464,7 +464,7 @@ body::-webkit-scrollbar-corner {
   border-radius: 0 0.3em 0.3em 0;
 }
 
-/* Please enable JS for additional font-colouring features */
+/* Please enable JS for additional colouring features */
 :root {
   --rssguard-red: 0;
   --rssguard-green: 0;
@@ -488,7 +488,7 @@ body::-webkit-scrollbar-corner {
 body,
 ::selection,
 mark, code, pre, pre > code,
-blockquote {
+blockquote, blockquote p {
   color: hsla(0, 0%, calc( ( var(--rssguard-perceived-lightness) - var(--rssguard-threshold) ) * -10000000% ), 0.9);
 }
 

--- a/resources/skins/nudus-dark/html_style.scss
+++ b/resources/skins/nudus-dark/html_style.scss
@@ -4,23 +4,17 @@ $qtbg-base:     #373A3D !default; // clr_basbg
 $qtbg-button:   #323437 !default; // clr_altbg // button bg (scrollbar, alt bg)
 $qcselbg:       #8291AD !default; // clr_selbg
 
-//
-// Emulate fusion colour processing (dark only)
-//
+// {{{ Emulate Fusion colour processing (dark only)
 
-//
 // Scrollbar colours
-//
 
 //$qcbgbg:    lighten($qtbg-button, 6%); // See toolbar bg
 $bgscroll:      lighten($qtbg-button, 2%) !default; // track and corner bg
 $tr-border:     darken($qtbg-button, 4%) !default; // track brdr
 
-//
-// Scrollbar thumb
-//
+// {{{ Scrollbar thumb
 
-// bg gradient
+// Thumb bg gradient
 
 // Normal
 $thscrlin:      lighten($qtbg-button, 6%) !default;
@@ -33,17 +27,19 @@ $thscrlhvout:   $thscrlout;
 // Light outline
 $th-border:     lighten($qtbg-button, 15%) !default;
 
-//
-// HTML palette (Colours)
-//
+// }}}
+
+// }}}
+
+// {{{ HTML palette (Colours)
 
 $cbg00: $qtbg-base;
 
-// Irrelevant, because fg is overridden by the switcher ~~~
+// {{{ Irrelevant, because colour switcher (see below) overrides all fg colours (either with JS on or off)
 $cfg00: #f5f5f5 !default;
 $cfg10: #E2E2E2 !default;
 $cfg11: $cfg10;
-// ~~~
+// }}}
 
 $cbor2: #545556 !default;
 
@@ -54,9 +50,9 @@ $cmark:         #f8d08c66 !default; // 40% transparency
 
 $clink: $qcselbg;
 
-//
+// }}}
+
 // Other
-//
 
 $radius-unit: .3em !default;
 
@@ -65,14 +61,12 @@ $radius-unit: .3em !default;
 ;
 
 //
-// Dark HTML-style has following additions:
+// Dark CSS style has following additions:
 //
 
-//
-// Border around viewport
+// {{{ Border around viewport
 
-//  https://csswizardry.com/2010/12/simplified-page-borders-in-pure-css/
-//
+// https://csswizardry.com/2010/12/simplified-page-borders-in-pure-css/
 
 html::before,
 html::after,
@@ -113,9 +107,9 @@ body::after {
     left: 0;
 }
 
-//
-// Enhanced scrollbar
-//
+// }}}
+
+// {{{ Dark-coloured scrollbar
 
 ::-webkit-scrollbar {
     height: 13px;
@@ -212,7 +206,7 @@ $th-outline:
     }
 }
 
-// More complete borders for `body` scrollbar
+// Complete the borders for body scrollbar
 body::-webkit-scrollbar-thumb,
 body::-webkit-scrollbar-track {
 
@@ -259,14 +253,14 @@ body::-webkit-scrollbar-corner {
     }
 }
 
-//
-// Font colour switcher
+// }}}
 
-//  Thank you so much!!
-//  https://css-tricks.com/switch-font-color-for-different-backgrounds-with-css/
-//
+// {{{ Fg colour switcher
 
-/* Please enable JS for additional font-colouring features */
+// Thank you so much!!
+// https://css-tricks.com/switch-font-color-for-different-backgrounds-with-css/
+
+/* Please enable JS for additional colouring features */
 :root {
     // Default RGB values for background colour
     --rssguard-red: 0;
@@ -296,7 +290,7 @@ body::-webkit-scrollbar-corner {
 body,
 ::selection,
 mark, code, pre, pre > code,
-blockquote {
+blockquote, blockquote p { // TODO: why did not I add 'blockquote p' here before?
     color:
         hsla(
             0,
@@ -311,3 +305,5 @@ blockquote {
             .9
         );
 }
+// }}}
+// vim:foldmethod=marker

--- a/resources/skins/nudus-dark/html_style.scss
+++ b/resources/skins/nudus-dark/html_style.scss
@@ -41,7 +41,7 @@ $cbg00: $qtbg-base;
 
 // Irrelevant, because fg is overridden by the switcher ~~~
 $cfg00: #f5f5f5 !default;
-$cfg10: #D8D8D8 !default;
+$cfg10: #E2E2E2 !default;
 $cfg11: $cfg10;
 // ~~~
 

--- a/resources/skins/nudus-dark/metadata.xml
+++ b/resources/skins/nudus-dark/metadata.xml
@@ -1,14 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<skin version="0.1.4" base="nudus-base">
+<skin version="0.1.5" base="nudus-base">
   <author>
     <name>akinokonomi, martinrotter</name>
   </author>
-  <description>Dark variant of 'nudus-light' skin.</description>
+  <description>Dark variation of a simple, unclothed theme.</description>
   <palette>
-    <color key="FgInteresting">#85ACF6</color>
-    <color key="FgSelectedInteresting">#D9E3F7</color>
-    <color key="FgNewMessages">#c684f4</color>
-    <color key="FgSelectedNewMessages">#d3a3f4</color>
+    <color key="FgInteresting">#F2F2F2</color>
+    <color key="FgSelectedInteresting">#FFFFFF</color>
+    <color key="FgNewMessages">#85ACF6</color>
+    <color key="FgSelectedNewMessages">#D9E3F7</color>
     <color key="FgError">#DF5656</color>
     <color key="FgSelectedError">#910303</color>
     <color key="Allright">#44AA44</color>
@@ -30,7 +30,7 @@
       <color role="Window">#2D2F32</color>
       <color role="Button">#323437</color>
 
-      <color role="Text">#D8D8D8</color>
+      <color role="Text">#E2E2E2</color>
       <color role="BrightText">#373A3D</color>
       <color role="HighlightedText">#FFFFFF</color>
       <color role="PlaceholderText">#A7A7A7</color>
@@ -50,3 +50,6 @@
     </group>
   </style-palette>
 </skin>
+<!--
+    vim:ts=2:sw=2:et:
+    -->

--- a/resources/skins/nudus-light/metadata.xml
+++ b/resources/skins/nudus-light/metadata.xml
@@ -1,13 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<skin version="0.1.4" base="nudus-base">
+<skin version="0.1.5" base="nudus-base">
   <author>
     <name>akinokonomi, martinrotter</name>
   </author>
+  <description>Simple, unclothed theme.&#xA;In loving memory of the vergilius (not a person).</description>
   <palette>
-    <color key="FgInteresting">#3A6FE4</color>
-    <color key="FgSelectedInteresting">#F0F2FC</color>
-    <color key="FgNewMessages">#cc39e2</color>
-    <color key="FgSelectedNewMessages">#d57fe2</color>
+    <color key="FgInteresting">#11204F</color>
+    <color key="FgSelectedInteresting">#FFFFFF</color>
+    <color key="FgNewMessages">#3A6FE4</color>
+    <color key="FgSelectedNewMessages">#F0F2FC</color>
     <color key="FgError">#E74343</color>
     <color key="FgSelectedError">#FFD7D7</color>
     <color key="Allright">#77dd77</color>
@@ -15,3 +16,6 @@
   <forced-styles></forced-styles>
   <forced-skin-colors>false</forced-skin-colors>
 </skin>
+<!--
+    vim:ts=2:sw=2:et:
+    -->


### PR DESCRIPTION
* Both nudus skins: Update fg feed list colors in metadata.xml
Follow up to https://github.com/martinrotter/rssguard/commit/1e28d482fca8d990c7e32fb3021ac0ed4ba15fcf

* nudus-dark only: Making a UI foreground color a bit lighter, because some say it's problematic to tell normal font from bold (https://github.com/martinrotter/rssguard/issues/838). 
I can totally see how it could be difficult to tell apart because the fg color seems a bit too pale, so here we are. 