### PR TITLE
CI: Check for syntax errors or linting issues in Linux/macOS build script

### DIFF
--- a/.github/workflows/rssguard.yml
+++ b/.github/workflows/rssguard.yml
@@ -7,7 +7,24 @@ on:
     tags: ["*"]
 
 jobs:
+  check-build-script:
+    name: Check build script
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout source code
+        uses: actions/checkout@v3
+
+      - name: Check script syntax
+        run: bash -n ./resources/scripts/github-actions/build-linux-mac.sh
+
+      - name: Show shellcheck version
+        run: shellcheck --version
+
+      - name: Run shellcheck
+        run: shellcheck --color=always ./resources/scripts/github-actions/build-linux-mac.sh
+
   build-rssguard:
+    needs: check-build-script
     name: "${{ matrix.os }}; webengine = ${{ matrix.use_webengine }}; qt5 = ${{ matrix.use_qt5 }}"
     runs-on: "${{ matrix.os }}"
     strategy:


### PR DESCRIPTION
- CI: Check/lint the build script with `bash -n` and `shellcheck` before trying to build RSS Guard.
- Fix warnings given by `shellcheck`.
- Use `set -e` throughout the script to make errors more obvious.
- Introduce the `$app_id` variable (Linux-only), and use it where appropriate, to reduce code duplication.
- Use the already existing `$prefix` variable where appropriate, to reduce code duplication.
- Use an array instead of a string to build the GStreamer paths for `linuxdeployqt`.
