### PR TITLE
Set max-width for figure element (nudus skins)

### DIFF
--- a/resources/skins/nudus-base/html_style_base.scss
+++ b/resources/skins/nudus-base/html_style_base.scss
@@ -156,6 +156,11 @@ cite {
     font-weight: bold !important;
 }
 
+// override if width is defined in element's style attribute
+figure {
+    max-width: 100%;
+}
+
 figure > img {
     display: block;
 }

--- a/resources/skins/nudus-dark/html_style.css
+++ b/resources/skins/nudus-dark/html_style.css
@@ -140,6 +140,10 @@ cite {
   font-weight: bold !important;
 }
 
+figure {
+  max-width: 100%;
+}
+
 figure > img {
   display: block;
 }

--- a/resources/skins/nudus-dark/metadata.xml
+++ b/resources/skins/nudus-dark/metadata.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<skin version="0.1.5" base="nudus-base">
+<skin version="0.1.6" base="nudus-base">
   <author>
     <name>akinokonomi, martinrotter</name>
   </author>

--- a/resources/skins/nudus-light/html_style.css
+++ b/resources/skins/nudus-light/html_style.css
@@ -140,6 +140,10 @@ cite {
   font-weight: bold !important;
 }
 
+figure {
+  max-width: 100%;
+}
+
 figure > img {
   display: block;
 }

--- a/resources/skins/nudus-light/metadata.xml
+++ b/resources/skins/nudus-light/metadata.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<skin version="0.1.5" base="nudus-base">
+<skin version="0.1.6" base="nudus-base">
   <author>
     <name>akinokonomi, martinrotter</name>
   </author>


### PR DESCRIPTION
Seeing https://github.com/martinrotter/rssguard/issues/924 I found that, while other articles are just fine, that one article displays poorly in webengine version too.
This commit should fix that.


This patch **does not fix** the #924.
It's a fix for RSS Guard with webengine only.