### PR TITLE
Fix build error with the -Werror=return-type flag

### DIFF
--- a/src/librssguard/core/messageobject.cpp
+++ b/src/librssguard/core/messageobject.cpp
@@ -178,9 +178,11 @@ QString MessageObject::createLabelId(const QString& title, const QString& hex_co
 
   if (hex_color.isEmpty()) {
     // Generate color.
+      return nullptr;
   }
 
   // TODO: CONTINUE
+  return nullptr;
 }
 
 void MessageObject::addEnclosure(const QString& url, const QString& mime_type) const {


### PR DESCRIPTION
This flag is automatically enabled in openSUSE Tumbleweed.