### PR TITLE
Fix #992

### DIFF
--- a/src/librssguard/miscellaneous/skinfactory.cpp
+++ b/src/librssguard/miscellaneous/skinfactory.cpp
@@ -184,8 +184,8 @@ void SkinFactory::loadSkinFromData(const Skin& skin) {
     // palettes in some styles. Also in light mode,
     // colors are now derived from system.
 #if QT_VERSION >= 0x060500 // Qt >= 6.5.0
-    else {
-      qApp->setPalette(qt_fusionPalette(qApp->styleHints()->colorScheme() == Qt::ColorScheme::Dark));
+    else if (qApp->styleHints()->colorScheme() == Qt::ColorScheme::Light) {
+      qApp->setPalette(qt_fusionPalette(false));
     }
 #endif
   }


### PR DESCRIPTION
The only reliable way to fix #992 seems to only call `qApp->setPalette` when `Qt::ColorScheme::Light` mode is detected as both `Qt::ColorScheme::Dark` and `Qt::ColorScheme::Unknown` cause breakage, this PR attempts to do just that