### PR TITLE
Updated rssguard_cs.ts translators

### DIFF
--- a/localization/rssguard_cs.ts
+++ b/localization/rssguard_cs.ts
@@ -5266,7 +5266,7 @@ Tokeny vyprší: %2</translation>
         <location filename="../src/librssguard/miscellaneous/localization.cpp" line="92"/>
         <source>LANG_AUTHOR</source>
         <extracomment>Name of translator - optional.</extracomment>
-        <translation>Martin Rotter</translation>
+        <translation>Martin Rotter, IAmNotImportant</translation>
     </message>
     <message>
         <location filename="../src/librssguard/miscellaneous/localization.cpp" line="93"/>


### PR DESCRIPTION
Thought it would be good to add all translators on Transifex contributing to RSS Guard to the "Author" list in the localisation settings menu. 

Started with:

`- Added Transifex user "IAmNotImportant" to the list of Czech translators.`

If this is ok with you I'll update the translators for all the other languages.