### PR TITLE
Remove `<pre>` tags from Linux's AppData file

### DIFF
--- a/resources/desktop/rssguard.metainfo.xml.in
+++ b/resources/desktop/rssguard.metainfo.xml.in
@@ -31,10 +31,10 @@
       <li>Tiny Tiny RSS</li>
     </ul>
     <p>
-      Note for Flatpak users: The autostart feature can only work if you manually allow us access to the <pre>~/.config/autostart</pre> directory. You can easily do that with the following command:
+      Note for Flatpak users: The autostart feature can only work if you manually allow us access to the ~/.config/autostart directory. You can easily do that with the following command:
     </p>
     <p>
-      <pre>flatpak override --user --filesystem=xdg-config/autostart @APP_REVERSE_NAME@</pre>
+      flatpak override --user --filesystem=xdg-config/autostart @APP_REVERSE_NAME@
     </p>
   </description>
   <launchable type="desktop-id">@APP_REVERSE_NAME@.desktop</launchable>


### PR DESCRIPTION
The specification does not allow them:

https://www.freedesktop.org/software/appstream/docs/chap-Metadata.html#tag-description