### PR TITLE
Linux: AppStream metadata validation and minor changes

### DIFF
--- a/resources/desktop/rssguard.metainfo.xml.in
+++ b/resources/desktop/rssguard.metainfo.xml.in
@@ -45,6 +45,7 @@
     </screenshot>
   </screenshots>
   <url type="homepage">https://github.com/martinrotter/rssguard</url>
+  <url type="help">https://rssguard.readthedocs.io</url>
   <url type="bugtracker">https://github.com/martinrotter/rssguard/issues</url>
   <url type="donation">https://github.com/sponsors/martinrotter</url>
   <url type="translate">https://crowdin.com/project/rssguard</url>

--- a/resources/desktop/rssguard.metainfo.xml.in
+++ b/resources/desktop/rssguard.metainfo.xml.in
@@ -68,7 +68,9 @@
   <content_rating type="oars-1.0" />
   <content_rating type="oars-1.1" />
   <releases>
-    <release version="@APP_VERSION@" date="@DATE@" />
+    <release version="@APP_VERSION@" date="@DATE@">
+      <url>https://github.com/martinrotter/rssguard/releases/tag/@APP_VERSION@</url>
+    </release>
   </releases>
   <provides>
     <binary>@APP_LOW_NAME@</binary>

--- a/resources/desktop/rssguard.metainfo.xml.in
+++ b/resources/desktop/rssguard.metainfo.xml.in
@@ -40,8 +40,8 @@
   <launchable type="desktop-id">@APP_REVERSE_NAME@.desktop</launchable>
   <screenshots>
     <screenshot type="default">
-      <image>
-        https://raw.githubusercontent.com/martinrotter/rssguard/master/resources/graphics/official_pictures/main-window-linux.png</image>
+      <caption>The main window</caption>
+      <image>https://raw.githubusercontent.com/martinrotter/rssguard/master/resources/graphics/official_pictures/main-window-linux.png</image>
     </screenshot>
   </screenshots>
   <url type="homepage">https://github.com/martinrotter/rssguard</url>

--- a/resources/scripts/github-actions/build-linux-mac.sh
+++ b/resources/scripts/github-actions/build-linux-mac.sh
@@ -34,7 +34,7 @@ if [ $is_linux = true ]; then
   sudo add-apt-repository ppa:beineri/opt-qt-5.15.2-focal -y
   sudo apt-get update
 
-  sudo apt-get -qy install qt515tools qt515base qt515webengine qt515svg qt515multimedia qt515imageformats
+  sudo apt-get -qy install qt515tools qt515base qt515webengine qt515svg qt515multimedia qt515imageformats appstream-util
   sudo apt-get -qy install cmake ninja-build openssl libssl-dev libgl1-mesa-dev gstreamer1.0-alsa gstreamer1.0-nice gstreamer1.0-plugins-good gstreamer1.0-plugins-base gstreamer1.0-plugins-bad gstreamer1.0-plugins-ugly gstreamer1.0-qt5 gstreamer1.0-pulseaudio
 
   # The script below performs some broken testing, which ends up tripping 'set -e'.
@@ -83,6 +83,9 @@ cmake --build .
 cmake --install . --prefix "$prefix"
 
 if [ $is_linux = true ]; then
+  # Validate AppStream metadata.
+  echo 'Validating AppStream metadata...'
+  appstream-util validate-relax "$prefix/share/metainfo/$app_id.metainfo.xml"
   # Obtain linuxdeployqt.
   wget -qc https://github.com/probonopd/linuxdeployqt/releases/download/continuous/linuxdeployqt-continuous-x86_64.AppImage
   chmod a+x linuxdeployqt-continuous-x86_64.AppImage 


### PR DESCRIPTION
This PR introduces minor changes to the Linux AppStream metadata file, such as:

- Adding caption to the main screenshot
- Adding a link to the documentation
- Adding a link to the release notes

Additionally, the validation of this file is now done in GitHub Actions using [`appstream-util`](https://man.archlinux.org/man/extra/appstream-glib/appstream-util.1.en).