### PR TITLE
Remove remaining references to CMake's old `USE_WEBENGINE` option

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -126,10 +126,6 @@ option(ENABLE_COMPRESSED_SITEMAP "Enable support for gzip-compressed sitemap fee
 option(ENABLE_MEDIAPLAYER_QTMULTIMEDIA "Enable built-in media player. Requires QtMultimedia FFMPEG plugin." OFF)
 option(ENABLE_MEDIAPLAYER_LIBMPV "Enable built-in media player. Requires libmpv library." ON)
 
-if(USE_WEBENGINE)
-  set(NO_LITE ON)
-endif()
-
 # Import Qt libraries.
 set(QT6_MIN_VERSION 6.3.0)
 set(QT5_MIN_VERSION 5.12.0)

--- a/docs/source/contrib/compile.md
+++ b/docs/source/contrib/compile.md
@@ -9,7 +9,7 @@ Here's a quick example of how to build it on Linux:
 mkdir build-dir
 
 # Configure the project to build using Qt 6, and disable built-in web browser support
-cmake -B build-dir -S . -DCMAKE_INSTALL_PREFIX=/usr -DBUILD_WITH_QT6=ON -DUSE_WEBENGINE=OFF
+cmake -B build-dir -S . -DCMAKE_INSTALL_PREFIX=/usr -DBUILD_WITH_QT6=ON -DNO_LITE=OFF
 
 # Compile it (in parallel mode)
 cmake --build build-dir -j$(nproc)

--- a/docs/source/downloads.md
+++ b/docs/source/downloads.md
@@ -5,7 +5,7 @@ Official place to download RSS Guard is at [Github Releases page](https://github
 RSS Guard is also available in [repositories of many Linux distributions](https://repology.org/project/rssguard/versions), and via [Flathub](https://flathub.org/apps/search?q=rssguard).
 
 The are two different [flavors](#features/browseradblock):
-* Regular: Includes an (almost) full-blown integrated web browser (built with `-DUSE_WEBENGINE=ON`).
-* Lite: Includes simpler, safer (and less memory hungry integrated web browser (built with `-DUSE_WEBENGINE=OFF`).
+* Regular: Includes an (almost) full-blown integrated web browser (built with `-NO_LITE=ON`).
+* Lite: Includes simpler, safer (and less memory hungry integrated web browser (built with `-NO_LITE=OFF`).
 
 I highly recommend to download RSS Guard only from trusted sources.

--- a/resources/desktop/CMakeLists.txt
+++ b/resources/desktop/CMakeLists.txt
@@ -3,7 +3,7 @@ set(APPDATA_NAME_LITE "${APP_NAME} Lite")
 set(APPDATA_SUMMARY_REGULAR "Simple, yet powerful news feed reader")
 set(APPDATA_SUMMARY_LITE "${APPDATA_SUMMARY_REGULAR} (no built-in web browser)")
 
-if(USE_WEBENGINE)
+if(NO_LITE)
   set(APPDATA_NAME "${APPDATA_NAME_REGULAR}")
   set(APPDATA_SUMMARY "${APPDATA_SUMMARY_REGULAR}")
 else()

--- a/src/librssguard/gui/newspaperpreviewer.cpp
+++ b/src/librssguard/gui/newspaperpreviewer.cpp
@@ -16,7 +16,7 @@ NewspaperPreviewer::NewspaperPreviewer(int msg_height, RootItem* root, QList<Mes
   showMoreMessages();
 }
 
-#if defined(USE_WEBENGINE)
+#if defined(NO_LITE)
 
 WebBrowser* NewspaperPreviewer::webBrowser() const {
   return nullptr;


### PR DESCRIPTION
That option was renamed to `NO_LITE` in v4.6.0.

Fixes #1242.