### PR TITLE
Mark articles that begin with `<details>` as HTML

### DIFF
--- a/src/librssguard/miscellaneous/textfactory.cpp
+++ b/src/librssguard/miscellaneous/textfactory.cpp
@@ -76,7 +76,7 @@ bool TextFactory::couldBeHtml(const QString& string) {
   const QString sstring = string.simplified();
 
   return sstring.startsWith(QL1S("<!")) || sstring.startsWith(QL1S("<html")) || sstring.startsWith(QL1S("<figure")) ||
-         sstring.startsWith(QL1S("<article")) || Qt::mightBeRichText(sstring);
+         sstring.startsWith(QL1S("<article")) || sstring.startsWith(QL1S("<details")) || Qt::mightBeRichText(sstring);
 }
 
 QDateTime TextFactory::parseDateTime(const QString& date_time) {


### PR DESCRIPTION
This Brazilian news website called [Tecnoblog](https://tecnoblog.net/) will often begin their articles with the `<details>` tag, providing a short summary for them.

### Before:

![image](https://github.com/martinrotter/rssguard/assets/626206/bd0b4de6-632f-41d6-8a64-0b6ab510832a)


### After:

![image](https://github.com/martinrotter/rssguard/assets/626206/3835f1ef-3231-48de-b01c-c2f664fc4986)


Fixes #1293