### PR TITLE
Linux: Fixes for AppStream metadata validation using `appstreamcli`

### DIFF
--- a/resources/desktop/rssguard.metainfo.xml.in
+++ b/resources/desktop/rssguard.metainfo.xml.in
@@ -5,7 +5,9 @@
   <metadata_license>CC0-1.0</metadata_license>
   <project_license>GPL-3.0</project_license>
   <name>@APPDATA_NAME@</name>
-  <developer_name>Martin Rotter</developer_name>
+  <developer id="martinrotter.github.io">
+    <name>Martin Rotter</name>
+  </developer>
   <update_contact>rotter.martinos_AT_gmail.com</update_contact>
   <summary>@APPDATA_SUMMARY@</summary>
   <description>

--- a/resources/desktop/rssguard.metainfo.xml.in
+++ b/resources/desktop/rssguard.metainfo.xml.in
@@ -65,7 +65,6 @@
     <keyword translate="no">The Old Reader</keyword>
     <keyword translate="no">Tiny Tiny RSS</keyword>
   </keywords>
-  <content_rating type="oars-1.0" />
   <content_rating type="oars-1.1" />
   <releases>
     <release version="@APP_VERSION@" date="@DATE@">

--- a/resources/scripts/github-actions/build-linux-mac.sh
+++ b/resources/scripts/github-actions/build-linux-mac.sh
@@ -42,7 +42,7 @@ if [ $is_linux = true ]; then
   sudo add-apt-repository ppa:beineri/opt-qt-5.15.4-focal -y
   sudo apt-get update
 
-  sudo apt-get -qy install qt515tools qt515base qt515webengine qt515svg qt515multimedia qt515imageformats appstream-util
+  sudo apt-get -qy install qt515tools qt515base qt515webengine qt515svg qt515multimedia qt515imageformats appstream
   sudo apt-get -qy install cmake ninja-build openssl libssl-dev libgl1-mesa-dev gstreamer1.0-alsa gstreamer1.0-nice gstreamer1.0-plugins-good gstreamer1.0-plugins-base gstreamer1.0-plugins-bad gstreamer1.0-plugins-ugly gstreamer1.0-qt5 gstreamer1.0-pulseaudio libmpv-dev
 
   # The script below performs some broken testing, which ends up tripping 'set -e'.
@@ -93,7 +93,7 @@ cmake --install . --prefix "$prefix"
 if [ $is_linux = true ]; then
   # Validate AppStream metadata.
   echo 'Validating AppStream metadata...'
-  appstream-util validate-relax "$prefix/share/metainfo/$app_id.metainfo.xml"
+  appstreamcli validate "$prefix/share/metainfo/$app_id.metainfo.xml"
   # Obtain linuxdeployqt.
   wget -qc https://github.com/probonopd/linuxdeployqt/releases/download/continuous/linuxdeployqt-continuous-x86_64.AppImage
   chmod a+x linuxdeployqt-continuous-x86_64.AppImage 


### PR DESCRIPTION
These changes are necessary, especially for Flathub, because they've recently replaced the previous validation tool (called [`appstream-util`](https://github.com/hughsie/appstream-glib)) by [`appstreamcli`](https://github.com/ximion/appstream), and so there are new error messages that we have to deal with...