### PR TITLE
Linux: Update developer ID in AppStream metadata

### DIFF
--- a/resources/desktop/rssguard.metainfo.xml.in
+++ b/resources/desktop/rssguard.metainfo.xml.in
@@ -5,7 +5,7 @@
   <metadata_license>CC0-1.0</metadata_license>
   <project_license>GPL-3.0</project_license>
   <name>@APPDATA_NAME@</name>
-  <developer id="martinrotter.github.io">
+  <developer id="io.github.martinrotter">
     <name>Martin Rotter</name>
   </developer>
   <update_contact>rotter.martinos_AT_gmail.com</update_contact>


### PR DESCRIPTION
This probably doesn't matter *that* much, but we should probably follow what the [documentation](https://www.freedesktop.org/software/appstream/docs/chap-Metadata.html#tag-developer) recommends:

>It is recommended to use a reverse-DNS name, like `org.gnome` or `io.github.ximion`, or a Fediverse handle (like `@user@example.org`) as ID to achieve a higher chance of uniqueness.


Sorry I set the wrong ID in my previous pull request, by the way... :x