### PR TITLE
Force libmpv to use the "libmpv" video output

### DIFF
--- a/src/librssguard/gui/mediaplayer/libmpv/libmpvbackend.cpp
+++ b/src/librssguard/gui/mediaplayer/libmpv/libmpvbackend.cpp
@@ -54,6 +54,11 @@ LibMpvBackend::LibMpvBackend(Application* app, QWidget* parent)
   mpv_set_option_string(m_mpvHandle, "config", "yes");
   mpv_set_option_string(m_mpvHandle, "script-opts", "osc-idlescreen=no");
   mpv_set_option_string(m_mpvHandle, "hwdec", "auto");
+
+#if defined(MEDIAPLAYER_LIBMPV_OPENGL)
+  mpv_set_option_string(m_mpvHandle, "vo", "libmpv");
+#endif
+    
   mpv_set_option_string(m_mpvHandle, "osd-playing-msg", "${media-title}");
   mpv_set_option_string(m_mpvHandle, "osc", "yes");
   mpv_set_option_string(m_mpvHandle, "input-cursor", "yes");


### PR DESCRIPTION
Starting from version 0.38.0, libmpv stopped using the `libmpv` video output (`vo` option) by default, which ends up causing mpv to spawn its own, separate and detached window, instead of just embedding itself onto RSS Guard's internal media player.

Upstream commit: https://github.com/mpv-player/mpv/commit/0e441525cfc2c0d56b6d4a5fc67016d7e29d1b2c