### PR TITLE
Use the same library search path as the install path on Unix platforms

### DIFF
--- a/src/librssguard/CMakeLists.txt
+++ b/src/librssguard/CMakeLists.txt
@@ -636,6 +636,10 @@ if(WIN32 OR OS2)
 elseif(UNIX AND NOT APPLE AND NOT ANDROID)
   include (GNUInstallDirs)
   install(TARGETS rssguard DESTINATION ${CMAKE_INSTALL_LIBDIR})
+  target_compile_definitions(rssguard
+    PRIVATE
+    RSSGUARD_LIBDIR="${CMAKE_INSTALL_LIBDIR}"
+  )
   set(HEADERS_FOLDER "${CMAKE_INSTALL_INCLUDEDIR}/librssguard")
 elseif(APPLE)
   install(TARGETS rssguard DESTINATION Contents/MacOS)

--- a/src/librssguard/miscellaneous/pluginfactory.cpp
+++ b/src/librssguard/miscellaneous/pluginfactory.cpp
@@ -29,6 +29,7 @@ QList<ServiceEntryPoint*> PluginFactory::loadPlugins() const {
                           QDirIterator::IteratorFlag::NoIteratorFlags);
 #endif
 
+    qDebugNN << LOGSEC_CORE << "Checking for plugins in " << plugin_folder;
     while (dir_iter.hasNext()) {
       dir_iter.next();
 
@@ -63,8 +64,8 @@ QList<ServiceEntryPoint*> PluginFactory::loadPlugins() const {
 QStringList PluginFactory::pluginPaths() const {
   QStringList paths;
 #if defined(Q_OS_LINUX)
-  paths << QCoreApplication::applicationDirPath() + QDir::separator() + QL1S("..") + QDir::separator() + QL1S("lib") +
-             QDir::separator() + QL1S(APP_LOW_NAME);
+  paths << QCoreApplication::applicationDirPath() + QDir::separator() + QL1S("..") + QDir::separator() +
+             QL1S(RSSGUARD_LIBDIR) + QDir::separator() + QL1S(APP_LOW_NAME);
 #elif defined(Q_OS_WIN)
   paths << QCoreApplication::applicationDirPath() + QDir::separator() + QL1S("plugins");
 #else


### PR DESCRIPTION
Some distributions use `lib64` for shared libraries. This breaks the plugin search logic.

Added a `-D` define to use the same path as is configured by CMake.