### PR TITLE
Fix LIKE statements using double quotes instead of single ones

### DIFF
--- a/src/librssguard/database/databasequeries.cpp
+++ b/src/librssguard/database/databasequeries.cpp
@@ -42,13 +42,13 @@ QMap<int, QString> DatabaseQueries::messageTableAttributes(bool only_msg_table, 
 
   if (is_sqlite) {
     field_names[MSG_DB_LABELS] =
-      QSL("(SELECT GROUP_CONCAT(Labels.name) FROM Labels WHERE Messages.labels LIKE \"%.\" || "
-          "Labels.custom_id || \".%\") as msg_labels");
+      QSL("(SELECT GROUP_CONCAT(Labels.name) FROM Labels WHERE Messages.labels LIKE '%.' || "
+          "Labels.custom_id || '.%') as msg_labels");
   }
   else {
     field_names[MSG_DB_LABELS] =
-      QSL("(SELECT GROUP_CONCAT(Labels.name) FROM Labels WHERE Messages.labels LIKE CONCAT(\"%.\", "
-          "Labels.custom_id, \".%\")) as msg_labels");
+      QSL("(SELECT GROUP_CONCAT(Labels.name) FROM Labels WHERE Messages.labels LIKE CONCAT('%.', "
+          "Labels.custom_id, '.%')) as msg_labels");
   }
 
   field_names[MSG_DB_LABELS_IDS] = QSL("Messages.labels");

--- a/src/librssguard/services/abstract/serviceroot.cpp
+++ b/src/librssguard/services/abstract/serviceroot.cpp
@@ -918,7 +918,7 @@ bool ServiceRoot::loadMessagesForItem(RootItem* item, MessagesModel* model) {
   else if (item->kind() == RootItem::Kind::Label) {
     // Show messages with particular label.
     model->setFilter(QSL("Messages.is_deleted = 0 AND Messages.is_pdeleted = 0 AND "
-                         "Messages.labels LIKE \"%.%2.%\" AND Messages.account_id = %1")
+                         "Messages.labels LIKE '%.%2.%' AND Messages.account_id = %1")
                        .arg(QString::number(accountId()), item->customId()));
   }
   else if (item->kind() == RootItem::Kind::Labels) {


### PR DESCRIPTION
Hello,

Thanks for developping rssguard.

On FreeBSD, rssguard 4.6.6 does not list any feed entry at all and the following critical errors appears on stderr :

```
time="     0.353" type="critical" -> message-model: Error when setting new msg view query: 'no such column: "%." - should this be a string literal in single-quotes? Unable to execute statement'.
time="     0.353" type="critical" -> message-model: Used SQL select statement: 'SELECT Messages.id, Messages.is_read, Messages.is_important, Messages.is_deleted, Messages.is_pdeleted, Messages.feed, Messages.title, Messages.url, Messages.author, Messages.date_created, Messages.contents, Messages.enclosures, Messages.score, Messages.account_id, Messages.custom_id, Messages.custom_hash, Feeds.title, Feeds.is_rtl, CASE WHEN LENGTH(Messages.enclosures) > 10 THEN 'true' ELSE 'false' END AS has_enclosures, (SELECT GROUP_CONCAT(Labels.name) FROM Labels WHERE Messages.labels LIKE "%." || Labels.custom_id || ".%") as msg_labels, Messages.labels FROM Messages LEFT JOIN Feeds ON Messages.feed = Feeds.custom_id AND Messages.account_id = Feeds.account_id WHERE 0 > 1;'.
```

It seems that comes from using double-quotes instead of single ones in LIKE statements.

The attached patch fixes the situation and allows feeds to be displayed correctly.

Cheers,

Ganael.