### PR TITLE
Remove Qt5 support

### DIFF
--- a/.github/workflows/rssguard.yml
+++ b/.github/workflows/rssguard.yml
@@ -29,25 +29,20 @@ jobs:
 
   build-rssguard:
     needs: check-build-script
-    name: "${{ matrix.os }}; no-lite = ${{ matrix.no_lite }}; qt5 = ${{ matrix.use_qt5 }}"
+    name: "${{ matrix.os }}; no-lite = ${{ matrix.no_lite }}; qt-version = ${{ matrix.qt_version }}"
     runs-on: "${{ matrix.os }}"
     strategy:
       matrix:
-        os: [windows-2022, ubuntu-20.04, macos-13]
+        os: [windows-2022, ubuntu-24.04, macos-13]
         no_lite: ["ON", "OFF"]
-        use_qt5: ["ON", "OFF"]
+        qt_version: ["6.3", "6.7"]
         include:
           - os: windows-2022
             script_name: .\resources\scripts\github-actions\build-windows.ps1
-          - os: ubuntu-20.04
+          - os: ubuntu-24.04
             script_name: ./resources/scripts/github-actions/build-linux-mac.sh
           - os: macos-13
             script_name: ./resources/scripts/github-actions/build-linux-mac.sh
-        exclude:
-          - os: ubuntu-20.04
-            use_qt5: "OFF"
-          - os: macos-13
-            use_qt5: "ON"
     steps:         
       - name: Checkout source code
         uses: actions/checkout@v4
@@ -56,7 +51,7 @@ jobs:
           submodules: true
          
       - name: Prepare environment and compile application
-        run: ${{ matrix.script_name }} "${{ matrix.os }}" "${{ matrix.no_lite }}" "${{ matrix.use_qt5 }}"
+        run: ${{ matrix.script_name }} "${{ matrix.os }}" "${{ matrix.no_lite }}" "${{ matrix.qt_version }}"
         env:
           GMAIL_CLIENT_ID: ${{ secrets.GMAIL_CLIENT_ID }}
           GMAIL_CLIENT_SECRET: ${{ secrets.GMAIL_CLIENT_SECRET }}
@@ -68,7 +63,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           if-no-files-found: error
-          name: RSS_Guard-${{ runner.os }}${{ matrix.no_lite == 'ON' && '-' || '-nowebengine-' }}Qt${{ matrix.use_qt5 == 'ON' && '5' || '6' }}
+          name: RSS_Guard-${{ runner.os }}${{ matrix.no_lite == 'ON' && '-' || '-nowebengine-' }}Qt${{ matrix.qt_version }}
           path: |
             ./rssguard-build/rssguard-*win*.exe
             ./rssguard-build/rssguard-*win*.7z
@@ -79,7 +74,7 @@ jobs:
     name: distribute-binaries
     needs:
       - build-rssguard
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     permissions:
       contents: write
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,7 +19,6 @@
 #     cmake --install .
 #
 # Variables:
-#   BUILD_WITH_QT6 - Build either with Qt 6 or Qt 5.
 #   USE_SYSTEM_SQLITE - Use system-wide SQLite3 library and header file. Defaults to "ON".
 #   NO_UPDATE_CHECK - Disable automatic checking for new application updates.
 #   IS_FLATPAK_BUILD - Set to "ON" when building RSS Guard with Flatpak.
@@ -42,7 +41,6 @@
 #
 # Other information:
 #   - supports Windows, Linux, *BSD, macOS, OS/2, Android,
-#   - Qt 5.14.0 or newer is required,
 #   - Qt 6.3.0 or newer is required,
 #   - cmake 3.14.0 or newer is required,
 #   - if you wish to make packages for Windows, then you must initialize all submodules
@@ -52,7 +50,7 @@
 # Building on OS/2:
 #   RSS Guard can run on OS/2 and if you want to compile it by yourself, you need to make sure that
 #   your OS/2 distro is up-to-date and you have all dependencies installed: os2-base, all gcc-* packages,
-#   libc and libcx up-to-date, kbuild-make, ash, binutils, all relevant qt5-* packages.
+#   libc and libcx up-to-date, kbuild-make, ash, binutils, all relevant qt6-* packages.
 #
 #   After your dependecies are installed, then you can compile via standard `cmake -> make -> make install` steps
 #   and package with: 7z.exe a -t7z -mmt -mx9 "rssguard.7z" "<build-folder\src\rssguard\app\*" command.
@@ -117,7 +115,6 @@ if(FORCE_COLORED_OUTPUT)
 endif()
 
 # Global compilation switches.
-option(BUILD_WITH_QT6 "Build application with Qt 6." ON)
 option(USE_SYSTEM_SQLITE "Use system-wide SQLite3 library." ON)
 option(NO_LITE "Enable QtWebEngine and other more demanding components." ON)
 option(UPDATE_TRANSLATIONS "Call lupdate to update translation files from source (Qt 6 only)." OFF)
@@ -133,10 +130,10 @@ option(MEDIAPLAYER_FORCE_OPENGL "Use opengl-based render API with libmpv." ON)
 
 # Import Qt libraries.
 set(QT6_MIN_VERSION 6.3.0)
-set(QT5_MIN_VERSION 5.14.0)
 
 set(QT_COMPONENTS
   Core
+  Core5Compat
   Gui
   LinguistTools
   Network
@@ -146,10 +143,6 @@ set(QT_COMPONENTS
   Xml
   Concurrent
 )
-
-if(WIN32 AND NOT BUILD_WITH_QT6)
-  list(APPEND QT_COMPONENTS WinExtras)
-endif()
 
 if(NOT OS2)
   list(APPEND QT_COMPONENTS Multimedia)
@@ -176,11 +169,7 @@ if(ENABLE_MEDIAPLAYER_LIBMPV)
   if(MEDIAPLAYER_FORCE_OPENGL)
     message(STATUS "Forcing OpenGL-based rendering for libmpv.")
 
-    list(APPEND QT_COMPONENTS OpenGL)
-
-    if(BUILD_WITH_QT6)
-      list(APPEND QT_COMPONENTS OpenGLWidgets)
-    endif()
+    list(APPEND QT_COMPONENTS OpenGL OpenGLWidgets)
 
     add_compile_definitions(MEDIAPLAYER_LIBMPV_OPENGL)
   endif()
@@ -204,36 +193,8 @@ if(UNIX AND NOT APPLE AND NOT ANDROID)
   list(APPEND QT_COMPONENTS DBus)
 endif()
 
-if(BUILD_WITH_QT6)
-  find_package(QT NAMES Qt6)
-  find_package(Qt6 ${QT6_MIN_VERSION} COMPONENTS ${QT_COMPONENTS} Core5Compat REQUIRED)
-else()
-  find_package(QT NAMES Qt5)
-  find_package(Qt5 ${QT5_MIN_VERSION} COMPONENTS ${QT_COMPONENTS} REQUIRED)
-
-  if(Qt5Core_VERSION VERSION_LESS 5.15.0)
-    # Compatibility macros.
-    macro(qt_wrap_ui)
-      qt5_wrap_ui(${ARGN})
-    endmacro()
-
-    macro(qt_add_resources)
-      qt5_add_resources(${ARGN})
-    endmacro()
-
-    macro(qt_add_big_resources)
-      qt5_add_big_resources(${ARGN})
-    endmacro()
-
-    macro(qt_create_translation)
-      qt5_create_translation(${ARGN})
-    endmacro()
-
-    macro(qt_add_translation)
-      qt5_add_translation(${ARGN})
-    endmacro()
-  endif()
-endif()
+find_package(QT NAMES Qt6)
+find_package(Qt6 ${QT6_MIN_VERSION} COMPONENTS ${QT_COMPONENTS} REQUIRED)
 
 # Load git commit hash.
 if(REVISION_FROM_GIT AND EXISTS "${CMAKE_SOURCE_DIR}/.git")

--- a/docs/source/contrib/compile.md
+++ b/docs/source/contrib/compile.md
@@ -8,8 +8,8 @@ Here's a quick example of how to build it on Linux:
 # Create a build directory
 mkdir build-dir
 
-# Configure the project to build using Qt 6, and disable built-in web browser support
-cmake -B build-dir -S . -DCMAKE_INSTALL_PREFIX=/usr -DBUILD_WITH_QT6=ON -DNO_LITE=OFF
+# Configure the project to disable built-in web browser support
+cmake -B build-dir -S . -DCMAKE_INSTALL_PREFIX=/usr -DNO_LITE=OFF
 
 # Compile it (in parallel mode)
 cmake --build build-dir -j$(nproc)

--- a/localization/CMakeLists.txt
+++ b/localization/CMakeLists.txt
@@ -1,4 +1,4 @@
-if(UPDATE_TRANSLATIONS AND BUILD_WITH_QT6)
+if(UPDATE_TRANSLATIONS)
   # Regenerate "en" .ts file.
   #
   # "en" .ts file is only used as "source" language
@@ -20,18 +20,8 @@ FILE(GLOB TS_FILES  ${CMAKE_CURRENT_SOURCE_DIR}/*.ts)
 
 set_source_files_properties(${TS_FILES} PROPERTIES OUTPUT_LOCATION "${CMAKE_CURRENT_SOURCE_DIR}")
 
-if(BUILD_WITH_QT6)
-  qt_add_lrelease(rssguard
-    TS_FILES ${TS_FILES}
-    QM_FILES_OUTPUT_VARIABLE QM_FILES
-    OPTIONS "-compress"
-  )
-else()
-  qt_add_translation(QM_FILES
-    ${TS_FILES}
-    OPTIONS "-compress"
-  )
-
-  add_custom_target(rssguard_lrelease DEPENDS ${QM_FILES})
-  add_dependencies(rssguard rssguard_lrelease)
-endif()
+qt_add_lrelease(rssguard
+  TS_FILES ${TS_FILES}
+  QM_FILES_OUTPUT_VARIABLE QM_FILES
+  OPTIONS "-compress"
+)

--- a/resources/android/AndroidManifest.xml
+++ b/resources/android/AndroidManifest.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <manifest package="com.rotter.rssguard" xmlns:android="http://schemas.android.com/apk/res/android" android:versionName="1.0" android:versionCode="1" android:installLocation="auto">
-    <application android:hardwareAccelerated="true" android:name="org.qtproject.qt5.android.bindings.QtApplication" android:label="RSS Guard" android:icon="@drawable/icon">
-        <activity android:configChanges="orientation|uiMode|screenLayout|screenSize|smallestScreenSize|layoutDirection|locale|fontScale|keyboard|keyboardHidden|navigation" android:name="org.qtproject.qt5.android.bindings.QtActivity" android:label="rssguard" android:screenOrientation="unspecified" android:launchMode="singleTop">
+    <application android:hardwareAccelerated="true" android:name="org.qtproject.qt6.android.bindings.QtApplication" android:label="RSS Guard" android:icon="@drawable/icon">
+        <activity android:configChanges="orientation|uiMode|screenLayout|screenSize|smallestScreenSize|layoutDirection|locale|fontScale|keyboard|keyboardHidden|navigation" android:name="org.qtproject.qt6.android.bindings.QtActivity" android:label="rssguard" android:screenOrientation="unspecified" android:launchMode="singleTop">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN"/>
                 <category android:name="android.intent.category.LAUNCHER"/>

--- a/resources/skins/nudus-light/html_style.scss
+++ b/resources/skins/nudus-light/html_style.scss
@@ -4,7 +4,7 @@
 // Colours
 //
 
-$cbg00: #FBFBFB !default; // Background // Qt5 fusion bg light toolbar-grey
+$cbg00: #FBFBFB !default; // Background // Qt6 fusion bg light toolbar-grey
 
 $cfg00: #000000 !default;
 //$cfg10: #A23542 !default; // TODO: fg for code

--- a/resources/skins/nudus-light/qt_style.qss
+++ b/resources/skins/nudus-light/qt_style.qss
@@ -7,7 +7,7 @@ QSplitter::handle {
 }
 
 /*
- * For `qt5-styleplugins`: motif, cde, gtk2, etc.
+ * For `qt6-styleplugins`: motif, cde, gtk2, etc.
  */
 QStatusBar::item {
     border: none;

--- a/src/librssguard-greader/src/greadernetwork.cpp
+++ b/src/librssguard-greader/src/greadernetwork.cpp
@@ -477,12 +477,8 @@ QStringList GreaderNetwork::itemIds(const QString& stream_id,
 
     if (newer_than.isValid()) {
       full_url += QSL("&ot=%1").arg(
-#if QT_VERSION < 0x050E00 // Qt < 5.14.0
-        QDateTime(newer_than)
-#else
         newer_than
           .startOfDay()
-#endif
           .toSecsSinceEpoch());
     }
 
@@ -615,12 +611,8 @@ QList<Message> GreaderNetwork::streamContents(ServiceRoot* root, const QString& 
 
     if (m_newerThanFilter.isValid()) {
       full_url += QSL("&ot=%1").arg(
-#if QT_VERSION < 0x050E00 // Qt < 5.14.0
-        QDateTime(m_newerThanFilter)
-#else
         m_newerThanFilter
           .startOfDay()
-#endif
           .toSecsSinceEpoch());
     }
 

--- a/src/librssguard-standard/CMakeLists.txt
+++ b/src/librssguard-standard/CMakeLists.txt
@@ -68,11 +68,9 @@ endif(ZLIB_FOUND)
 
 prepare_rssguard_plugin(${PLUGIN_TARGET})
 
-if(QT_VERSION_MAJOR EQUAL 6)
-  target_link_libraries(${PLUGIN_TARGET} PUBLIC
-    Qt${QT_VERSION_MAJOR}::Core5Compat
-  )
-endif()
+target_link_libraries(${PLUGIN_TARGET} PUBLIC
+  Qt${QT_VERSION_MAJOR}::Core5Compat
+)
 
 if(ZLIB_FOUND)
   target_include_directories(${PLUGIN_TARGET} AFTER

--- a/src/librssguard-standard/src/gui/formdiscoverfeeds.cpp
+++ b/src/librssguard-standard/src/gui/formdiscoverfeeds.cpp
@@ -178,12 +178,8 @@ void FormDiscoverFeeds::discoverFeeds() {
     return res;
   };
 
-#if QT_VERSION_MAJOR == 5
-  QFuture<QList<StandardFeed*>> fut = QtConcurrent::mappedReduced<QList<StandardFeed*>>(m_parsers, func, reducer);
-#else
   QFuture<QList<StandardFeed*>> fut =
     QtConcurrent::mappedReduced<QList<StandardFeed*>>(qApp->workHorsePool(), m_parsers, func, reducer);
-#endif
 
   m_watcherLookup.setFuture(fut);
 

--- a/src/librssguard-standard/src/standardfeedsimportexportmodel.cpp
+++ b/src/librssguard-standard/src/standardfeedsimportexportmodel.cpp
@@ -437,11 +437,7 @@ void FeedsImportExportModel::importAsOPML20(const QByteArray& data,
     return produceFeed(lookup);
   };
 
-#if QT_VERSION_MAJOR == 5
-  QFuture<bool> fut = QtConcurrent::mapped(m_lookup, func);
-#else
   QFuture<bool> fut = QtConcurrent::mapped(qApp->workHorsePool(), m_lookup, func);
-#endif
 
   m_watcherLookup.setFuture(fut);
 
@@ -506,11 +502,7 @@ void FeedsImportExportModel::importAsTxtURLPerLine(const QByteArray& data,
     return produceFeed(lookup);
   };
 
-#if QT_VERSION_MAJOR == 5
-  QFuture<bool> fut = QtConcurrent::mapped(m_lookup, func);
-#else
   QFuture<bool> fut = QtConcurrent::mapped(qApp->workHorsePool(), m_lookup, func);
-#endif
 
   m_watcherLookup.setFuture(fut);
 

--- a/src/librssguard/3rd-party/sc/simplecrypt.cpp
+++ b/src/librssguard/3rd-party/sc/simplecrypt.cpp
@@ -98,11 +98,7 @@ QByteArray SimpleCrypt::encryptToByteArray(QByteArray plaintext) {
     flags |= CryptoFlagChecksum;
     QDataStream s(&integrityProtection, QIODevice::WriteOnly);
 
-#if QT_VERSION_MAJOR == 6
     s << qChecksum(ba);
-#else
-    s << qChecksum(ba, ba.length());
-#endif
   }
   else if (m_protectionMode == ProtectionHash) {
     flags |= CryptoFlagHash;
@@ -226,11 +222,7 @@ QByteArray SimpleCrypt::decryptToByteArray(QByteArray cypher) {
     }
 
     ba = ba.mid(2);
-#if QT_VERSION_MAJOR == 6
     quint16 checksum = qChecksum(ba);
-#else
-    quint16 checksum = qChecksum(ba, ba.length());
-#endif
 
     integrityOk = (checksum == storedChecksum);
   }

--- a/src/librssguard/CMakeLists.txt
+++ b/src/librssguard/CMakeLists.txt
@@ -541,6 +541,7 @@ endif()
 # Qt.
 target_link_libraries(rssguard PUBLIC
   Qt${QT_VERSION_MAJOR}::Core
+  Qt${QT_VERSION_MAJOR}::Core5Compat
   Qt${QT_VERSION_MAJOR}::Gui
   Qt${QT_VERSION_MAJOR}::Network
   Qt${QT_VERSION_MAJOR}::Qml
@@ -549,12 +550,6 @@ target_link_libraries(rssguard PUBLIC
   Qt${QT_VERSION_MAJOR}::Xml
   Qt${QT_VERSION_MAJOR}::Concurrent
 )
-
-if(QT_VERSION_MAJOR EQUAL 6)
-  target_link_libraries(rssguard PUBLIC
-    Qt${QT_VERSION_MAJOR}::Core5Compat
-  )
-endif()
 
 if(WIN32)
   target_link_libraries(rssguard PUBLIC
@@ -565,12 +560,6 @@ endif()
 if(NO_LITE)
   target_link_libraries(rssguard PUBLIC
     Qt${QT_VERSION_MAJOR}::WebEngineWidgets
-  )
-endif()
-
-if(WIN32 AND NOT BUILD_WITH_QT6)
-  target_link_libraries(rssguard PUBLIC
-    Qt${QT_VERSION_MAJOR}::WinExtras
   )
 endif()
 
@@ -589,13 +578,8 @@ elseif(ENABLE_MEDIAPLAYER_LIBMPV)
   if(MEDIAPLAYER_FORCE_OPENGL)
     target_link_libraries(rssguard PUBLIC
       Qt${QT_VERSION_MAJOR}::OpenGL
-    )
-
-    if(BUILD_WITH_QT6)
-      target_link_libraries(rssguard PUBLIC
-        Qt${QT_VERSION_MAJOR}::OpenGLWidgets
+      Qt${QT_VERSION_MAJOR}::OpenGLWidgets
       )
-    endif()
   endif()
 
   target_include_directories(rssguard AFTER

--- a/src/librssguard/core/feeddownloader.cpp
+++ b/src/librssguard/core/feeddownloader.cpp
@@ -162,9 +162,7 @@ void FeedDownloader::updateFeeds(const QList<Feed*>& feeds) {
     };
 
     m_watcherLookup.setFuture(QtConcurrent::mapped(
-#if QT_VERSION_MAJOR > 5
       qApp->workHorsePool(),
-#endif
       m_feeds,
       func));
   }

--- a/src/librssguard/core/feedsproxymodel.cpp
+++ b/src/librssguard/core/feedsproxymodel.cpp
@@ -90,11 +90,7 @@ QModelIndexList FeedsProxyModel::match(const QModelIndex& start,
         QString item_text = item_value.toString();
 
         switch (match_type) {
-#if QT_VERSION >= 0x050F00 // Qt >= 5.15.0
           case Qt::MatchFlag::MatchRegularExpression:
-#else
-          case Qt::MatchFlag::MatchRegExp:
-#endif
             if (QRegularExpression(entered_text,
                                    QRegularExpression::PatternOption::CaseInsensitiveOption |
                                      QRegularExpression::PatternOption::UseUnicodePropertiesOption)

--- a/src/librssguard/core/message.cpp
+++ b/src/librssguard/core/message.cpp
@@ -27,11 +27,7 @@ QList<Enclosure> Enclosures::decodeEnclosuresFromString(const QString& enclosure
   if (enc_err.error != QJsonParseError::ParseError::NoError) {
     // Provide backwards compatibility.
     auto enc = enclosures_data.split(ENCLOSURES_OUTER_SEPARATOR,
-#if QT_VERSION >= 0x050F00 // Qt >= 5.15.0
                                      Qt::SplitBehaviorFlags::SkipEmptyParts);
-#else
-                                     QString::SplitBehavior::SkipEmptyParts);
-#endif
 
     enclosures.reserve(enc.size());
 
@@ -224,12 +220,7 @@ Message Message::fromSqlRecord(const QSqlRecord& record, bool* result) {
   message.m_customHash = record.value(MSG_DB_CUSTOM_HASH_INDEX).toString();
   message.m_assignedLabelsIds = record.value(MSG_DB_LABELS_IDS)
                                   .toString()
-                                  .split('.',
-#if QT_VERSION >= 0x050F00 // Qt >= 5.15.0
-                                         Qt::SplitBehaviorFlags::SkipEmptyParts);
-#else
-                                         QString::SplitBehavior::SkipEmptyParts);
-#endif
+                                  .split('.', Qt::SplitBehaviorFlags::SkipEmptyParts);
 
   if (result != nullptr) {
     *result = true;

--- a/src/librssguard/core/messagesmodel.cpp
+++ b/src/librssguard/core/messagesmodel.cpp
@@ -74,11 +74,7 @@ QIcon MessagesModel::generateIconForScore(double score) {
   paint.fillPath(path, Qt::GlobalColor::white);
   paint.drawPath(path);
 
-#if QT_VERSION >= 0x050D00 // Qt >= 5.13.0
   path.clear();
-#else
-  path = QPainterPath();
-#endif
 
   paint.setPen(Qt::GlobalColor::transparent);
 

--- a/src/librssguard/core/messagesproxymodel.cpp
+++ b/src/librssguard/core/messagesproxymodel.cpp
@@ -301,11 +301,7 @@ QModelIndexList MessagesProxyModel::match(const QModelIndex& start,
         QString item_text = item_value.toString();
 
         switch (match_type) {
-#if QT_VERSION >= 0x050F00 // Qt >= 5.15.0
           case Qt::MatchFlag::MatchRegularExpression:
-#else
-          case Qt::MatchFlag::MatchRegExp:
-#endif
             if (QRegularExpression(entered_text,
                                    QRegularExpression::PatternOption::CaseInsensitiveOption |
                                      QRegularExpression::PatternOption::UseUnicodePropertiesOption)

--- a/src/librssguard/database/databasedriver.cpp
+++ b/src/librssguard/database/databasedriver.cpp
@@ -73,11 +73,7 @@ QStringList DatabaseDriver::prepareScript(const QString& base_sql_folder,
   QString next_file = base_sql_folder + QDir::separator() + sql_file;
   QString sql_script = QString::fromUtf8(IOFactory::readFile(next_file));
   QStringList new_statements = sql_script.split(QSL(APP_DB_COMMENT_SPLIT),
-#if QT_VERSION >= 0x050F00 // Qt >= 5.15.0
                                                 Qt::SplitBehaviorFlags::SkipEmptyParts);
-#else
-                                                QString::SplitBehavior::SkipEmptyParts);
-#endif
 
   for (int i = 0; i < new_statements.size(); i++) {
     if (new_statements.at(i).startsWith(QSL(APP_DB_INCLUDE_PLACEHOLDER))) {
@@ -87,11 +83,7 @@ QStringList DatabaseDriver::prepareScript(const QString& base_sql_folder,
       QString included_file = base_sql_folder + QDir::separator() + included_file_name;
       QString included_sql_script = QString::fromUtf8(IOFactory::readFile(included_file));
       QStringList included_statements = included_sql_script.split(QSL(APP_DB_COMMENT_SPLIT),
-#if QT_VERSION >= 0x050F00 // Qt >= 5.15.0
                                                                   Qt::SplitBehaviorFlags::SkipEmptyParts);
-#else
-                                                                  QString::SplitBehavior::SkipEmptyParts);
-#endif
 
       statements << included_statements;
     }

--- a/src/librssguard/database/databasefactory.cpp
+++ b/src/librssguard/database/databasefactory.cpp
@@ -80,21 +80,6 @@ DatabaseDriver* DatabaseFactory::driverForType(DatabaseDriver::DriverType d) con
 QString DatabaseFactory::lastExecutedQuery(const QSqlQuery& query) {
   QString str = query.lastQuery();
 
-#if QT_VERSION_MAJOR == 5
-  QMapIterator<QString, QVariant> it(query.boundValues());
-
-  while (it.hasNext()) {
-    it.next();
-
-    if (it.value().type() == QVariant::Type::Char || it.value().type() == QVariant::Type::String) {
-      str.replace(it.key(), QSL("'%1'").arg(it.value().toString()));
-    }
-    else {
-      str.replace(it.key(), it.value().toString());
-    }
-  }
-#endif
-
   return str;
 }
 

--- a/src/librssguard/database/databasequeries.cpp
+++ b/src/librssguard/database/databasequeries.cpp
@@ -199,11 +199,7 @@ QList<Label*> DatabaseQueries::getLabelsForMessage(const QSqlDatabase& db,
 
   if (q.exec() && q.next()) {
     auto label_ids = q.value(0).toString().split('.',
-#if QT_VERSION >= 0x050F00 // Qt >= 5.15.0
                                                  Qt::SplitBehaviorFlags::SkipEmptyParts);
-#else
-                                                 QString::SplitBehavior::SkipEmptyParts);
-#endif
 
     auto iter = boolinq::from(installed_labels);
 

--- a/src/librssguard/definitions/definitions.h
+++ b/src/librssguard/definitions/definitions.h
@@ -398,13 +398,8 @@
 //
 // Source code specific enhancements.
 //
-#if QT_VERSION >= 0x050E00 // Qt >= 5.14.0
 #define FROM_STD_LIST(x, y)    (x(y.begin(), y.end()))
 #define FROM_LIST_TO_SET(x, y) (x(y.begin(), y.end()))
-#else
-#define FROM_STD_LIST(x, y)    (x::fromStdList(y))
-#define FROM_LIST_TO_SET(x, y) (x::fromList(y))
-#endif
 
 #ifndef qDebugNN
 #define qDebugNN qDebug().noquote().nospace()

--- a/src/librssguard/gui/dialogs/formabout.cpp
+++ b/src/librssguard/gui/dialogs/formabout.cpp
@@ -117,11 +117,7 @@ void FormAbout::loadLicenseAndInformation() {
   }
 
   try {
-#if QT_VERSION >= 0x050E00 // Qt >= 5.14.0
     m_ui.m_txtChangelog->setMarkdown(IOFactory::readFile(APP_INFO_PATH + QL1S("/CHANGELOG")));
-#else
-    m_ui.m_txtChangelog->setText(IOFactory::readFile(APP_INFO_PATH + QL1S("/CHANGELOG")));
-#endif
 
     m_ui.m_txtChangelog->document()->setIndentWidth(16.0);
   }

--- a/src/librssguard/gui/dialogs/formmain.cpp
+++ b/src/librssguard/gui/dialogs/formmain.cpp
@@ -39,16 +39,10 @@
 #include <QFileDialog>
 #include <QRect>
 #include <QScopedPointer>
+#include <QScreen>
 #include <QTimer>
 #include <QToolButton>
 #include <QWidgetAction>
-
-#if QT_VERSION >= 0x050E00 // Qt >= 5.14.0
-#include <QScreen>
-#else
-#include <QDesktopWidget>
-#endif
-
 #include <QWindow>
 
 FormMain::FormMain(QWidget* parent, Qt::WindowFlags f)
@@ -663,7 +657,6 @@ void FormMain::setupIcons() {
 }
 
 void FormMain::loadSize() {
-#if QT_VERSION >= 0x050E00 // Qt >= 5.14.0
   QScreen* scr = screen();
 
   if (scr == nullptr) {
@@ -672,9 +665,6 @@ void FormMain::loadSize() {
   }
 
   const QRect screen = scr->geometry();
-#else
-  const QRect screen = qApp->desktop()->screenGeometry();
-#endif
 
   const Settings* settings = qApp->settings();
 

--- a/src/librssguard/gui/dialogs/formupdate.cpp
+++ b/src/librssguard/gui/dialogs/formupdate.cpp
@@ -74,12 +74,7 @@ void FormUpdate::checkForUpdates() {
               m_updateInfo = update.first.at(0);
               m_ui.m_tabInfo->setEnabled(true);
               m_ui.m_lblAvailableRelease->setText(m_updateInfo.m_availableVersion);
-
-#if QT_VERSION >= 0x050E00 // Qt >= 5.14.0
               m_ui.m_txtChanges->setMarkdown(m_updateInfo.m_changes);
-#else
-      m_ui.m_txtChanges->setText(m_updateInfo.m_changes);
-#endif
 
               if (SystemFactory::isVersionNewer(m_updateInfo.m_availableVersion, QSL(APP_VERSION))) {
                 m_btnUpdate->setVisible(true);

--- a/src/librssguard/gui/mediaplayer/libmpv/libmpvwidget.cpp
+++ b/src/librssguard/gui/mediaplayer/libmpv/libmpvwidget.cpp
@@ -109,7 +109,7 @@ void LibMpvWidget::initializeGL() {
   mpv_opengl_init_params gl_init_params[1] = {get_proc_address, nullptr};
   mpv_render_param display{MPV_RENDER_PARAM_INVALID, nullptr};
 
-#if QT_VERSION_MAJOR == 6 && defined(Q_OS_UNIX) && !defined(Q_OS_DARWIN) && !defined(Q_OS_ANDROID)
+#if defined(Q_OS_UNIX) && !defined(Q_OS_DARWIN) && !defined(Q_OS_ANDROID)
 #if defined(QT_FEATURE_xcb)
   if (QGuiApplication::platformName() == QStringLiteral("xcb")) {
     display.type = MPV_RENDER_PARAM_X11_DISPLAY;

--- a/src/librssguard/gui/mediaplayer/libmpv/qthelper.h
+++ b/src/librssguard/gui/mediaplayer/libmpv/qthelper.h
@@ -149,11 +149,7 @@ namespace mpv {
           // "QVariant::Type(obsolete), the return value should be interpreted
           // as QMetaType::Type."
           // So a cast really seems to be needed to avoid warnings (urgh).
-#if QT_VERSION_MAJOR == 5
-          return v.type() == static_cast<int>(t);
-#else
           return v.typeId() == static_cast<int>(t);
-#endif
         }
         void set(mpv_node* dst, const QVariant& src) {
           if (test_type(src, QMetaType::QString)) {

--- a/src/librssguard/gui/mediaplayer/qtmultimedia/qtmultimediabackend.h
+++ b/src/librssguard/gui/mediaplayer/qtmultimedia/qtmultimediabackend.h
@@ -8,17 +8,7 @@
 #include <QMediaPlayer>
 #include <QObject>
 
-#if QT_VERSION_MAJOR == 6
-#define PLAYBACK_STATE        PlaybackState
-#define PLAYBACK_STATE_METHOD playbackState
-#else
-#define PLAYBACK_STATE        State
-#define PLAYBACK_STATE_METHOD state
-#endif
-
-#if QT_VERSION_MAJOR == 6
 class QAudioOutput;
-#endif
 
 class QVideoWidget;
 
@@ -51,7 +41,7 @@ class QtMultimediaBackend : public PlayerBackend {
     void onAudioAvailable(bool available);
     void onVideoAvailable(bool available);
     void onMediaStatusChanged(QMediaPlayer::MediaStatus status);
-    void onPlaybackStateChanged(QMediaPlayer::PLAYBACK_STATE state);
+    void onPlaybackStateChanged(QMediaPlayer::PlaybackState state);
     void onPositionChanged(qint64 position);
     void onSeekableChanged(bool seekable);
 
@@ -68,9 +58,7 @@ class QtMultimediaBackend : public PlayerBackend {
     QString mediaStatusToString(QMediaPlayer::MediaStatus status) const;
 
   private:
-#if QT_VERSION_MAJOR == 6
     QAudioOutput* m_audio;
-#endif
 
     QMediaPlayer* m_player;
     QVideoWidget* m_video;

--- a/src/librssguard/gui/reusable/styleditemdelegatewithoutfocus.h
+++ b/src/librssguard/gui/reusable/styleditemdelegatewithoutfocus.h
@@ -4,12 +4,7 @@
 #define STYLEDITEMDELEGATEWITHOUTFOCUS_H
 
 #include <QStyledItemDelegate>
-
-#if QT_VERSION_MAJOR <= 5
-#include <QStyleOptionViewItemV4>
-#else
 #include <QStyleOptionViewItem>
-#endif
 
 class StyledItemDelegateWithoutFocus : public QStyledItemDelegate {
     Q_OBJECT

--- a/src/librssguard/gui/settings/settingsgui.cpp
+++ b/src/librssguard/gui/settings/settingsgui.cpp
@@ -123,12 +123,7 @@ bool SettingsGui::eventFilter(QObject* obj, QEvent* e) {
   if (e->type() == QEvent::Type::Drop) {
     auto* drop_event = static_cast<QDropEvent*>(e);
 
-#if QT_VERSION_MAJOR == 6
-    if (drop_event->modifiers() !=
-#else
-    if (drop_event->keyboardModifiers() !=
-#endif
-        Qt::KeyboardModifier::NoModifier) {
+    if (drop_event->modifiers() != Qt::KeyboardModifier::NoModifier) {
       drop_event->setDropAction(Qt::DropAction::MoveAction);
     }
   }

--- a/src/librssguard/gui/toolbars/feedstoolbar.cpp
+++ b/src/librssguard/gui/toolbars/feedstoolbar.cpp
@@ -95,24 +95,14 @@ void FeedsToolBar::loadSpecificActions(const QList<QAction*>& actions, bool init
 
 QStringList FeedsToolBar::defaultActions() const {
   return QString(GUI::FeedsToolbarActionsDef)
-    .split(',',
-#if QT_VERSION >= 0x050F00 // Qt >= 5.15.0
-           Qt::SplitBehaviorFlags::SkipEmptyParts);
-#else
-           QString::SplitBehavior::SkipEmptyParts);
-#endif
+    .split(',', Qt::SplitBehaviorFlags::SkipEmptyParts);
 }
 
 QStringList FeedsToolBar::savedActions() const {
   return qApp->settings()
     ->value(GROUP(GUI), SETTING(GUI::FeedsToolbarActions))
     .toString()
-    .split(',',
-#if QT_VERSION >= 0x050F00 // Qt >= 5.15.0
-           Qt::SplitBehaviorFlags::SkipEmptyParts);
-#else
-           QString::SplitBehavior::SkipEmptyParts);
-#endif
+    .split(',', Qt::SplitBehaviorFlags::SkipEmptyParts);
 }
 
 void FeedsToolBar::initializeSearchBox() {

--- a/src/librssguard/gui/toolbars/messagestoolbar.cpp
+++ b/src/librssguard/gui/toolbars/messagestoolbar.cpp
@@ -400,22 +400,12 @@ void MessagesToolBar::activateAction(const QString& action_name, QWidgetAction* 
 
 QStringList MessagesToolBar::defaultActions() const {
   return QString(GUI::MessagesToolbarDefaultButtonsDef)
-    .split(QL1C(','),
-#if QT_VERSION >= 0x050F00 // Qt >= 5.15.0
-           Qt::SplitBehaviorFlags::SkipEmptyParts);
-#else
-           QString::SplitBehavior::SkipEmptyParts);
-#endif
+    .split(QL1C(','), Qt::SplitBehaviorFlags::SkipEmptyParts);
 }
 
 QStringList MessagesToolBar::savedActions() const {
   return qApp->settings()
     ->value(GROUP(GUI), SETTING(GUI::MessagesToolbarDefaultButtons))
     .toString()
-    .split(QL1C(','),
-#if QT_VERSION >= 0x050F00 // Qt >= 5.15.0
-           Qt::SplitBehaviorFlags::SkipEmptyParts);
-#else
-           QString::SplitBehavior::SkipEmptyParts);
-#endif
+    .split(QL1C(','), Qt::SplitBehaviorFlags::SkipEmptyParts);
 }

--- a/src/librssguard/gui/toolbars/statusbar.cpp
+++ b/src/librssguard/gui/toolbars/statusbar.cpp
@@ -65,24 +65,14 @@ void StatusBar::saveAndSetActions(const QStringList& actions) {
 
 QStringList StatusBar::defaultActions() const {
   return QString(GUI::StatusbarActionsDef)
-    .split(',',
-#if QT_VERSION >= 0x050F00 // Qt >= 5.15.0
-           Qt::SplitBehaviorFlags::SkipEmptyParts);
-#else
-           QString::SplitBehavior::SkipEmptyParts);
-#endif
+    .split(',', Qt::SplitBehaviorFlags::SkipEmptyParts);
 }
 
 QStringList StatusBar::savedActions() const {
   return qApp->settings()
     ->value(GROUP(GUI), SETTING(GUI::StatusbarActions))
     .toString()
-    .split(',',
-#if QT_VERSION >= 0x050F00 // Qt >= 5.15.0
-           Qt::SplitBehaviorFlags::SkipEmptyParts);
-#else
-           QString::SplitBehavior::SkipEmptyParts);
-#endif
+    .split(',', Qt::SplitBehaviorFlags::SkipEmptyParts);
 }
 
 QList<QAction*> StatusBar::convertActions(const QStringList& actions) {

--- a/src/librssguard/gui/webviewers/webengine/webengineviewer.cpp
+++ b/src/librssguard/gui/webviewers/webengine/webengineviewer.cpp
@@ -18,16 +18,10 @@
 #include <QGraphicsView>
 #include <QTimer>
 #include <QToolTip>
-#include <QWheelEvent>
-
-#if QT_VERSION_MAJOR == 6
 #include <QWebEngineContextMenuRequest>
-#else
-#include <QWebEngineContextMenuData>
-#endif
-
 #include <QWebEngineProfile>
 #include <QWebEngineSettings>
+#include <QWheelEvent>
 
 WebEngineViewer::WebEngineViewer(QWidget* parent) : QWebEngineView(parent), m_browser(nullptr), m_root(nullptr) {
   WebEnginePage* page = new WebEnginePage(this);
@@ -83,11 +77,7 @@ void WebEngineViewer::clear() {
 void WebEngineViewer::contextMenuEvent(QContextMenuEvent* event) {
   event->accept();
 
-#if QT_VERSION_MAJOR == 6
   QMenu* menu = createStandardContextMenu();
-#else
-  QMenu* menu = page()->createStandardContextMenu();
-#endif
 
   menu->removeAction(page()->action(QWebEnginePage::WebAction::OpenLinkInNewWindow));
 
@@ -258,12 +248,8 @@ QByteArray WebEngineViewer::getJsEnabledHtml(const QString& url, bool worker_thr
 }
 
 ContextMenuData WebEngineViewer::provideContextMenuData(QContextMenuEvent* event) const {
-#if QT_VERSION_MAJOR == 6
   auto* menu_pointer = lastContextMenuRequest();
   QWebEngineContextMenuRequest& menu_data = *menu_pointer;
-#else
-  QWebEngineContextMenuData menu_data = page()->contextMenuData();
-#endif
 
   ContextMenuData c;
 

--- a/src/librssguard/miscellaneous/application.h
+++ b/src/librssguard/miscellaneous/application.h
@@ -34,13 +34,7 @@ class FormLog;
 class IconFactory;
 class QAction;
 class Mutex;
-
-#if QT_VERSION_MAJOR == 6
 class QWebEngineDownloadRequest;
-#else
-class QWebEngineDownloadItem;
-#endif
-
 class WebFactory;
 class NotificationFactory;
 class ToastNotificationsManager;
@@ -232,11 +226,7 @@ class RSSGUARD_DLLSPEC Application : public SingleApplication {
     void onAdBlockFailure();
 
 #if defined(NO_LITE)
-#if QT_VERSION_MAJOR == 6
     void downloadRequested(QWebEngineDownloadRequest* download_item);
-#else
-    void downloadRequested(QWebEngineDownloadItem* download_item);
-#endif
 #endif
 
     void onFeedUpdatesStarted();

--- a/src/librssguard/miscellaneous/notification.cpp
+++ b/src/librssguard/miscellaneous/notification.cpp
@@ -7,12 +7,9 @@
 #include <QDir>
 
 #if !defined(Q_OS_OS2)
+#include <QAudioOutput>
 #include <QMediaPlayer>
 #include <QSoundEffect>
-
-#if QT_VERSION_MAJOR == 6
-#include <QAudioOutput>
-#endif
 #endif
 
 Notification::Notification(Notification::Event event,
@@ -69,7 +66,6 @@ void Notification::playSound(Application* app) const {
 
       QMediaPlayer* play = new QMediaPlayer(app);
 
-#if QT_VERSION_MAJOR == 6
       QAudioOutput* out = new QAudioOutput(app);
 
       play->setAudioOutput(out);
@@ -92,24 +88,6 @@ void Notification::playSound(Application* app) const {
 
       play->audioOutput()->setVolume(fractionalVolume());
       play->play();
-#else
-      QObject::connect(play, &QMediaPlayer::stateChanged, play, [play](QMediaPlayer::State state) {
-        if (state == QMediaPlayer::State::StoppedState) {
-          play->deleteLater();
-        }
-      });
-
-      if (m_soundPath.startsWith(QSL(":"))) {
-        play->setMedia(QMediaContent(QUrl(QSL("qrc") + m_soundPath)));
-      }
-      else {
-        play->setMedia(QMediaContent(
-          QUrl::fromLocalFile(QDir::toNativeSeparators(app->replaceUserDataFolderPlaceholder(m_soundPath)))));
-      }
-
-      play->setVolume(m_volume);
-      play->play();
-#endif
     }
 #endif
   }

--- a/src/librssguard/miscellaneous/skinfactory.cpp
+++ b/src/librssguard/miscellaneous/skinfactory.cpp
@@ -409,12 +409,7 @@ Skin SkinFactory::skinInfo(const QString& skin_name, bool lite, bool* ok) const 
       skin.m_forcedStyles = skin_node.namedItem(QSL("forced-styles"))
                               .toElement()
                               .text()
-                              .split(',',
-#if QT_VERSION >= 0x050F00 // Qt >= 5.15.0
-                                     Qt::SplitBehaviorFlags::SkipEmptyParts);
-#else
-                                     QString::SplitBehavior::SkipEmptyParts);
-#endif
+                              .split(',', Qt::SplitBehaviorFlags::SkipEmptyParts);
 
       skin.m_forcedSkinColors =
         skin_node.namedItem(QSL("forced-skin-colors")).toElement().text() == QVariant(true).toString();

--- a/src/librssguard/network-web/basenetworkaccessmanager.cpp
+++ b/src/librssguard/network-web/basenetworkaccessmanager.cpp
@@ -64,9 +64,7 @@ QNetworkReply* BaseNetworkAccessManager::createRequest(QNetworkAccessManager::Op
   new_request.setAttribute(QNetworkRequest::Attribute::HttpPipeliningAllowedAttribute, true);
 #endif
 
-#if QT_VERSION >= 0x050F00 // Qt >= 5.15.0
   new_request.setAttribute(QNetworkRequest::Attribute::Http2AllowedAttribute, m_enableHttp2);
-#endif
 
   // new_request.setMaximumRedirectsAllowed(0);
 

--- a/src/librssguard/network-web/downloader.cpp
+++ b/src/librssguard/network-web/downloader.cpp
@@ -283,12 +283,7 @@ QList<HttpResponse> Downloader::decodeMultipartAnswer(QNetworkReply* reply) {
 
   QRegularExpression regex(QL1S("--") + boundary + QL1S("(--)?(\\r\\n)?"));
 
-  QStringList list = QString::fromUtf8(data).split(regex,
-#if QT_VERSION >= 0x050F00 // Qt >= 5.15.0
-                                                   Qt::SplitBehaviorFlags::SkipEmptyParts);
-#else
-                                                   QString::SplitBehavior::SkipEmptyParts);
-#endif
+  QStringList list = QString::fromUtf8(data).split(regex, Qt::SplitBehaviorFlags::SkipEmptyParts);
 
   QList<HttpResponse> parts;
 
@@ -310,12 +305,7 @@ QList<HttpResponse> Downloader::decodeMultipartAnswer(QNetworkReply* reply) {
     QString headers =
       http_response_str.mid(start_of_headers, start_of_body - start_of_headers).replace(reg_whites, QSL("\n"));
 
-    auto header_lines = headers.split(QL1C('\n'),
-#if QT_VERSION >= 0x050F00 // Qt >= 5.15.0
-                                      Qt::SplitBehaviorFlags::SkipEmptyParts);
-#else
-                                      QString::SplitBehavior::SkipEmptyParts);
-#endif
+    auto header_lines = headers.split(QL1C('\n'), Qt::SplitBehaviorFlags::SkipEmptyParts);
 
     for (const QString& header_line : std::as_const(header_lines)) {
       int index_colon = header_line.indexOf(QL1C(':'));

--- a/src/librssguard/network-web/downloadmanager.cpp
+++ b/src/librssguard/network-web/downloadmanager.cpp
@@ -67,16 +67,7 @@ void DownloadItem::init() {
   m_reply->setParent(this);
 
   connect(m_reply, &QNetworkReply::readyRead, this, &DownloadItem::downloadReadyRead);
-
-#if QT_VERSION >= 0x050F00 // Qt >= 5.15.0
   connect(m_reply, &QNetworkReply::errorOccurred, this, &DownloadItem::error);
-#else
-  connect(m_reply,
-          static_cast<void (QNetworkReply::*)(QNetworkReply::NetworkError)>(&QNetworkReply::error),
-          this,
-          &DownloadItem::error);
-#endif
-
   connect(m_reply, &QNetworkReply::downloadProgress, this, &DownloadItem::downloadProgress);
   connect(m_reply, &QNetworkReply::metaDataChanged, this, &DownloadItem::metaDataChanged);
   connect(m_reply, &QNetworkReply::finished, this, &DownloadItem::finished);

--- a/src/librssguard/network-web/webengine/webenginepage.cpp
+++ b/src/librssguard/network-web/webengine/webenginepage.cpp
@@ -24,11 +24,7 @@ WebEnginePage::WebEnginePage(QObject* parent) : QWebEnginePage(qApp->web()->engi
 }
 
 WebEngineViewer* WebEnginePage::view() const {
-#if QT_VERSION_MAJOR == 6
   return qobject_cast<WebEngineViewer*>(QWebEngineView::forPage(this));
-#else
-  return qobject_cast<WebEngineViewer*>(QWebEnginePage::view());
-#endif
 }
 
 QString WebEnginePage::pageHtml(const QString& url) {

--- a/src/librssguard/network-web/webfactory.cpp
+++ b/src/librssguard/network-web/webfactory.cpp
@@ -19,12 +19,7 @@
 #if defined(NO_LITE)
 #include "network-web/webengine/networkurlinterceptor.h"
 
-#if QT_VERSION_MAJOR == 6
 #include <QWebEngineDownloadRequest>
-#else
-#include <QWebEngineDownloadItem>
-#endif
-
 #include <QWebEngineProfile>
 #include <QWebEngineScript>
 #include <QWebEngineScriptCollection>
@@ -58,11 +53,7 @@ WebFactory::WebFactory(QObject* parent) : QObject(parent), m_apiServer(nullptr),
   m_articleParse = new ArticleParse(this);
 
 #if defined(NO_LITE)
-#if QT_VERSION >= 0x050D00 // Qt >= 5.13.0
   m_engineProfile->setUrlRequestInterceptor(m_urlInterceptor);
-#else
-  m_engineProfile->setRequestInterceptor(m_urlInterceptor);
-#endif
 #endif
 }
 
@@ -524,10 +515,7 @@ void WebFactory::createMenu(QMenu* menu) {
                                         QWebEngineSettings::WebAttribute::JavascriptCanPaste);
   actions << createEngineSettingsAction(tr("DNS prefetch enabled"),
                                         QWebEngineSettings::WebAttribute::DnsPrefetchEnabled);
-
-#if QT_VERSION >= 0x050D00 // Qt >= 5.13.0
   actions << createEngineSettingsAction(tr("PDF viewer enabled"), QWebEngineSettings::WebAttribute::PdfViewerEnabled);
-#endif
 
   menu->addActions(actions);
 }

--- a/src/librssguard/services/abstract/cacheforserviceroot.cpp
+++ b/src/librssguard/services/abstract/cacheforserviceroot.cpp
@@ -68,13 +68,8 @@ void CacheForServiceRoot::addMessageStatesToCache(const QList<Message>& ids_of_m
   // Store changes, they will be sent to server later.
   list_act.append(ids_of_messages);
 
-#if QT_VERSION >= 0x050E00 // Qt >= 5.14.0
   QSet<Message> set_act(list_act.begin(), list_act.end());
   QSet<Message> set_other(list_other.begin(), list_other.end());
-#else
-  QSet<Message> set_act = list_act.toSet();
-  QSet<Message> set_other = list_other.toSet();
-#endif
 
   // Now, we want to remove all IDS from list_other, which are contained in list.
   set_other -= set_act;
@@ -99,13 +94,8 @@ void CacheForServiceRoot::addMessageStatesToCache(const QStringList& ids_of_mess
   // Store changes, they will be sent to server later.
   list_act.append(ids_of_messages);
 
-#if QT_VERSION >= 0x050E00 // Qt >= 5.14.0
   QSet<QString> set_act(list_act.begin(), list_act.end());
   QSet<QString> set_other(list_other.begin(), list_other.end());
-#else
-  QSet<QString> set_act = list_act.toSet();
-  QSet<QString> set_other = list_other.toSet();
-#endif
 
   // Now, we want to remove all IDS from list_other, which are contained in list.
   set_other -= set_act;

--- a/src/librssguard/services/abstract/serviceroot.h
+++ b/src/librssguard/services/abstract/serviceroot.h
@@ -332,17 +332,9 @@ class RSSGUARD_DLLSPEC ServiceRoot : public RootItem {
     bool m_nodeShowProbes;
 };
 
-#if QT_VERSION_MAJOR == 6
 inline size_t qHash(ServiceRoot::BagOfMessages key, size_t seed) {
   return ::qHash(static_cast<uint>(key), seed);
 }
-
-#else
-inline uint qHash(ServiceRoot::BagOfMessages key, uint seed) {
-  return ::qHash(static_cast<uint>(key), seed);
-}
-
-#endif
 
 ServiceRoot::LabelOperation operator|(ServiceRoot::LabelOperation lhs, ServiceRoot::LabelOperation rhs);
 ServiceRoot::LabelOperation operator&(ServiceRoot::LabelOperation lhs, ServiceRoot::LabelOperation rhs);

--- a/src/rssguard/CMakeLists.txt
+++ b/src/rssguard/CMakeLists.txt
@@ -19,16 +19,11 @@ target_include_directories(app PUBLIC
 
 target_link_libraries(app PUBLIC
   Qt${QT_VERSION_MAJOR}::Core
+  Qt${QT_VERSION_MAJOR}::Core5Compat
   Qt${QT_VERSION_MAJOR}::Gui
   Qt${QT_VERSION_MAJOR}::Widgets
   rssguard
 )
-
-if(QT_VERSION_MAJOR EQUAL 6)
-  target_link_libraries(app PUBLIC
-    Qt${QT_VERSION_MAJOR}::Core5Compat
-  )
-endif()
 
 if(APPLE)
   set_target_properties(app PROPERTIES

--- a/src/rssguard/main.cpp
+++ b/src/rssguard/main.cpp
@@ -13,15 +13,10 @@
 #endif
 
 #if defined(Q_OS_WIN)
-#if QT_VERSION_MAJOR == 5
-#include <QtPlatformHeaders/QWindowsWindowFunctions>
-#else
 #include <QWindow>
-#endif
 #endif
 
 #include <QSettings>
-#include <QTextCodec>
 
 int main(int argc, char* argv[]) {
   qSetMessagePattern(QSL("time=\"%{time process}\" type=\"%{type}\" -> %{message}"));
@@ -31,20 +26,11 @@ int main(int argc, char* argv[]) {
   qputenv("QT_DISABLE_AUDIO_PREPARE", "1");
 
   // High DPI stuff.
-#if QT_VERSION >= 0x050E00 // Qt >= 5.14.0
   auto high_dpi_existing_env = qgetenv("QT_ENABLE_HIGHDPI_SCALING");
 
   if (high_dpi_existing_env.isEmpty()) {
     qputenv("QT_ENABLE_HIGHDPI_SCALING", "1");
   }
-#else
-  qputenv("QT_AUTO_SCREEN_SCALE_FACTOR", "1");
-#endif
-
-#if QT_VERSION_MAJOR <= 5
-  QApplication::setAttribute(Qt::ApplicationAttribute::AA_UseHighDpiPixmaps);
-  QApplication::setAttribute(Qt::ApplicationAttribute::AA_EnableHighDpiScaling);
-#endif
 
 #if defined(Q_OS_UNIX) && !defined(Q_OS_MACOS)
   QGuiApplication::setDesktopFileName(APP_REVERSE_NAME);
@@ -70,10 +56,6 @@ int main(int argc, char* argv[]) {
   for (int a = 0; a < argc; a++) {
     raw_cli_args << QString::fromLocal8Bit(av[a]);
   }
-
-#if QT_VERSION_MAJOR == 5
-  QTextCodec::setCodecForLocale(QTextCodec::codecForName("UTF-8"));
-#endif
 
   // Set some names.
   QCoreApplication::setApplicationName(QSL(APP_NAME));
@@ -113,15 +95,6 @@ int main(int argc, char* argv[]) {
   QGuiApplication::setWindowIcon(qApp->desktopAwareIcon());
 
   qApp->reactOnForeignNotifications();
-
-#if defined(Q_OS_WIN)
-#if QT_VERSION_MAJOR == 5
-  QWindowsWindowFunctions::setHasBorderInFullScreenDefault(true);
-
-  // NOTE: https://github.com/martinrotter/rssguard/issues/953 for Qt 5.
-  QWindowsWindowFunctions::setWindowActivationBehavior(QWindowsWindowFunctions::AlwaysActivateWindow);
-#endif
-#endif
 
   FormMain main_window;
 


### PR DESCRIPTION
Virtually all Linux distros have updated to Plasma 6 which works best with Qt6 apps. At this point there's no real benefit to keeping Qt5 around, and the EOL of it is coming up (May of next year).

This PR rips out all support for Qt5, and adds Qt 6.3 to the CI matrix to ensure that support for it is maintained.

Note that Ubuntu images in CI were updated to 24.04 as that is the first version to include gstreamer1.0-qt6. This is causing the appimage build to fail with a "glibc is too new" error which I'm not sure how to resolve. My personal preference is to remove the appimage build as well in favor of just maintaining the flatpak as the distro-independent distrubtion method.