### PR TITLE
Add new setting for disabled feeds: Hide

### DIFF
--- a/src/librssguard/gui/settings/settingsfeedsmessages.cpp
+++ b/src/librssguard/gui/settings/settingsfeedsmessages.cpp
@@ -207,6 +207,7 @@ SettingsFeedsMessages::SettingsFeedsMessages(Settings* settings, QWidget* parent
           this,
           &SettingsFeedsMessages::dirtifySettings);
   connect(m_ui->m_checkShowTooltips, &QCheckBox::toggled, this, &SettingsFeedsMessages::dirtifySettings);
+  connect(m_ui->m_cbHideDisabledFeeds, &QCheckBox::toggled, this, &SettingsFeedsMessages::dirtifySettings);
   connect(m_ui->m_checkMultilineArticleList, &QCheckBox::toggled, this, &SettingsFeedsMessages::dirtifySettings);
   connect(m_ui->m_checkMultilineArticleList, &QCheckBox::toggled, this, &SettingsFeedsMessages::requireRestart);
 
@@ -352,6 +353,8 @@ void SettingsFeedsMessages::loadSettings() {
   m_ui->m_cmbCountsFeedList->setEditText(settings()->value(GROUP(Feeds), SETTING(Feeds::CountFormat)).toString());
   m_ui->m_checkShowTooltips
     ->setChecked(settings()->value(GROUP(Feeds), SETTING(Feeds::EnableTooltipsFeedsMessages)).toBool());
+ m_ui->m_cbHideDisabledFeeds
+    ->setChecked(settings()->value(GROUP(Feeds), SETTING(Feeds::HideDisabledFeeds)).toBool());
   m_ui->m_cmbIgnoreContentsChanges
     ->setChecked(settings()->value(GROUP(Messages), SETTING(Messages::IgnoreContentsChanges)).toBool());
   m_ui->m_checkMultilineArticleList
@@ -489,6 +492,7 @@ void SettingsFeedsMessages::saveSettings() {
   settings()->setValue(GROUP(Feeds), Feeds::FeedsUpdateStartupDelay, m_ui->m_spinStartupUpdateDelay->value());
   settings()->setValue(GROUP(Feeds), Feeds::CountFormat, m_ui->m_cmbCountsFeedList->currentText());
   settings()->setValue(GROUP(Feeds), Feeds::EnableTooltipsFeedsMessages, m_ui->m_checkShowTooltips->isChecked());
+  settings()->setValue(GROUP(Feeds), Feeds::HideDisabledFeeds, m_ui->m_cbHideDisabledFeeds->isChecked());
   settings()->setValue(GROUP(Messages), Messages::IgnoreContentsChanges, m_ui->m_cmbIgnoreContentsChanges->isChecked());
   settings()->setValue(GROUP(Messages), Messages::MultilineArticleList, m_ui->m_checkMultilineArticleList->isChecked());
   settings()->setValue(GROUP(Messages),

--- a/src/librssguard/gui/settings/settingsfeedsmessages.ui
+++ b/src/librssguard/gui/settings/settingsfeedsmessages.ui
@@ -266,6 +266,13 @@
          </property>
         </widget>
        </item>
+       <item row="8" column="0" colspan="2">
+        <widget class="QCheckBox" name="m_cbHideDisabledFeeds">
+         <property name="text">
+          <string>Hide disabled feeds</string>
+         </property>
+        </widget>
+       </item>
        <item row="5" column="0" colspan="2">
         <widget class="QCheckBox" name="m_cbUpdateFeedListDuringFetching">
          <property name="text">
@@ -727,6 +734,7 @@
   <tabstop>m_cbUpdateFeedListDuringFetching</tabstop>
   <tabstop>m_cbListsRestrictedShortcuts</tabstop>
   <tabstop>m_checkShowTooltips</tabstop>
+  <tabstop>m_cbHideDisabledFeeds</tabstop>
   <tabstop>m_checkRemoveReadMessagesOnExit</tabstop>
   <tabstop>m_cbArticleViewerAlwaysVisible</tabstop>
   <tabstop>m_cmbIgnoreContentsChanges</tabstop>

--- a/src/librssguard/miscellaneous/settings.cpp
+++ b/src/librssguard/miscellaneous/settings.cpp
@@ -98,6 +98,9 @@ DVALUE(char*) Feeds::CountFormatDef = "(%unread)";
 DKEY Feeds::EnableTooltipsFeedsMessages = "show_tooltips";
 DVALUE(bool) Feeds::EnableTooltipsFeedsMessagesDef = true;
 
+DKEY Feeds::HideDisabledFeeds = "hide_disabled_feeds";
+DVALUE(bool) Feeds::HideDisabledFeedsDef = false;
+
 DKEY Feeds::PauseFeedFetching = "pause_feed_fetching";
 DVALUE(bool) Feeds::PauseFeedFetchingDef = false;
 

--- a/src/librssguard/miscellaneous/settings.h
+++ b/src/librssguard/miscellaneous/settings.h
@@ -94,6 +94,9 @@ namespace Feeds {
   KEY EnableTooltipsFeedsMessages;
   VALUE(bool) EnableTooltipsFeedsMessagesDef;
 
+  KEY HideDisabledFeeds;
+  VALUE(bool) HideDisabledFeedsDef;
+
   KEY PauseFeedFetching;
   VALUE(bool) PauseFeedFetchingDef;
 


### PR DESCRIPTION
When enabled, this feature "**Hide disabled feeds**" will automatically filter out and hide any disabled feeds from the feed list, providing a cleaner and more streamlined view for users. This enhancement will improve usability by reducing clutter and allowing users to focus only on active feeds.

> **NB :** This feature works seamlessly as a complementary addition to the other committed features, such as [Strikethrough](https://github.com/martinrotter/rssguard/pull/1651) and [Custom color options](https://github.com/martinrotter/rssguard/pull/1652) Together, these options provide users with a comprehensive set of tools to customize and manage their feed list effectively, catering to different preferences and workflows.


![1 - Setting](https://github.com/user-attachments/assets/41b34203-1fdf-48bf-a3e1-d5d770ff0c62)

<div style="text-align: center;">
  <table>
    <tr>
      <th>Enabled</th>
      <th>Disabled</th>
    </tr>
    <tr>
      <td><img src="https://github.com/user-attachments/assets/fe3a8109-d546-466d-84bb-29480da2fae7" alt="2 - B_1"></td>
      <td><img src="https://github.com/user-attachments/assets/56bd90ec-9453-4a2d-88eb-88ab315e62e1" alt="2 - B_2"></td>
    </tr>
  </table>
</div>
