### PR TITLE
Add new setting for disabled feeds: Strikethrough

### DIFF
--- a/src/librssguard/core/feedsmodel.cpp
+++ b/src/librssguard/core/feedsmodel.cpp
@@ -554,14 +554,12 @@ QVariant FeedsModel::data(const QModelIndex& index, int role) const {
     case Qt::ItemDataRole::FontRole: {
       RootItem* it = itemForIndex(index);
       bool is_bold = it->countOfUnreadMessages() > 0;
-      bool is_striked = it->kind() == RootItem::Kind::Feed ? qobject_cast<Feed*>(it)->isSwitchedOff() : false;
+      bool is_striked = it->kind() == RootItem::Kind::Feed &&
+                        qApp->settings()->value(GROUP(Feeds), SETTING(Feeds::StrikethroughDisabledFeeds)).toBool() &&
+                        qobject_cast<Feed*>(it)->isSwitchedOff();
 
-      if (is_bold) {
-        return is_striked ? m_boldStrikedFont : m_boldFont;
-      }
-      else {
-        return is_striked ? m_normalStrikedFont : m_normalFont;
-      }
+      return is_bold ? (is_striked ? m_boldStrikedFont : m_boldFont)
+                     : (is_striked ? m_normalStrikedFont : m_normalFont);
     }
 
     case Qt::ItemDataRole::ToolTipRole:

--- a/src/librssguard/gui/settings/settingsfeedsmessages.cpp
+++ b/src/librssguard/gui/settings/settingsfeedsmessages.cpp
@@ -207,6 +207,7 @@ SettingsFeedsMessages::SettingsFeedsMessages(Settings* settings, QWidget* parent
           this,
           &SettingsFeedsMessages::dirtifySettings);
   connect(m_ui->m_checkShowTooltips, &QCheckBox::toggled, this, &SettingsFeedsMessages::dirtifySettings);
+  connect(m_ui->m_cbStrikethroughDisabledFeeds, &QCheckBox::toggled, this, &SettingsFeedsMessages::dirtifySettings);
   connect(m_ui->m_checkMultilineArticleList, &QCheckBox::toggled, this, &SettingsFeedsMessages::dirtifySettings);
   connect(m_ui->m_checkMultilineArticleList, &QCheckBox::toggled, this, &SettingsFeedsMessages::requireRestart);
 
@@ -352,6 +353,8 @@ void SettingsFeedsMessages::loadSettings() {
   m_ui->m_cmbCountsFeedList->setEditText(settings()->value(GROUP(Feeds), SETTING(Feeds::CountFormat)).toString());
   m_ui->m_checkShowTooltips
     ->setChecked(settings()->value(GROUP(Feeds), SETTING(Feeds::EnableTooltipsFeedsMessages)).toBool());
+  m_ui->m_cbStrikethroughDisabledFeeds
+    ->setChecked(settings()->value(GROUP(Feeds), SETTING(Feeds::StrikethroughDisabledFeeds)).toBool());
   m_ui->m_cmbIgnoreContentsChanges
     ->setChecked(settings()->value(GROUP(Messages), SETTING(Messages::IgnoreContentsChanges)).toBool());
   m_ui->m_checkMultilineArticleList
@@ -489,6 +492,7 @@ void SettingsFeedsMessages::saveSettings() {
   settings()->setValue(GROUP(Feeds), Feeds::FeedsUpdateStartupDelay, m_ui->m_spinStartupUpdateDelay->value());
   settings()->setValue(GROUP(Feeds), Feeds::CountFormat, m_ui->m_cmbCountsFeedList->currentText());
   settings()->setValue(GROUP(Feeds), Feeds::EnableTooltipsFeedsMessages, m_ui->m_checkShowTooltips->isChecked());
+  settings()->setValue(GROUP(Feeds), Feeds::StrikethroughDisabledFeeds, m_ui->m_cbStrikethroughDisabledFeeds->isChecked());
   settings()->setValue(GROUP(Messages), Messages::IgnoreContentsChanges, m_ui->m_cmbIgnoreContentsChanges->isChecked());
   settings()->setValue(GROUP(Messages), Messages::MultilineArticleList, m_ui->m_checkMultilineArticleList->isChecked());
   settings()->setValue(GROUP(Messages),

--- a/src/librssguard/gui/settings/settingsfeedsmessages.ui
+++ b/src/librssguard/gui/settings/settingsfeedsmessages.ui
@@ -266,6 +266,13 @@
          </property>
         </widget>
        </item>
+       <item row="9" column="0" colspan="2">
+        <widget class="QCheckBox" name="m_cbStrikethroughDisabledFeeds">
+         <property name="text">
+          <string>Strikethrough disabled feed titles</string>
+         </property>
+        </widget>
+       </item>
        <item row="5" column="0" colspan="2">
         <widget class="QCheckBox" name="m_cbUpdateFeedListDuringFetching">
          <property name="text">
@@ -727,6 +734,7 @@
   <tabstop>m_cbUpdateFeedListDuringFetching</tabstop>
   <tabstop>m_cbListsRestrictedShortcuts</tabstop>
   <tabstop>m_checkShowTooltips</tabstop>
+  <tabstop>m_cbStrikethroughDisabledFeeds</tabstop>
   <tabstop>m_checkRemoveReadMessagesOnExit</tabstop>
   <tabstop>m_cbArticleViewerAlwaysVisible</tabstop>
   <tabstop>m_cmbIgnoreContentsChanges</tabstop>

--- a/src/librssguard/miscellaneous/settings.cpp
+++ b/src/librssguard/miscellaneous/settings.cpp
@@ -98,6 +98,9 @@ DVALUE(char*) Feeds::CountFormatDef = "(%unread)";
 DKEY Feeds::EnableTooltipsFeedsMessages = "show_tooltips";
 DVALUE(bool) Feeds::EnableTooltipsFeedsMessagesDef = true;
 
+DKEY Feeds::StrikethroughDisabledFeeds = "strikethrough_disabled_feeds";
+DVALUE(bool) Feeds::StrikethroughDisabledFeedsDef = false;
+
 DKEY Feeds::PauseFeedFetching = "pause_feed_fetching";
 DVALUE(bool) Feeds::PauseFeedFetchingDef = false;
 

--- a/src/librssguard/miscellaneous/settings.h
+++ b/src/librssguard/miscellaneous/settings.h
@@ -94,6 +94,9 @@ namespace Feeds {
   KEY EnableTooltipsFeedsMessages;
   VALUE(bool) EnableTooltipsFeedsMessagesDef;
 
+  KEY StrikethroughDisabledFeeds;
+  VALUE(bool) StrikethroughDisabledFeedsDef;
+
   KEY PauseFeedFetching;
   VALUE(bool) PauseFeedFetchingDef;
 


### PR DESCRIPTION
This add a new checkbox option labeled "**Strikethrough disabled feed titles**" to the user interface.
This feature will apply a strikethrough effect to the titles of disabled feeds in the feed list.

> **NB :** This feature works seamlessly as a complementary addition to the other committed features, such as [Custom color options](https://github.com/martinrotter/rssguard/pull/1652) and [Hide](https://github.com/martinrotter/rssguard/pull/1650) Together, these options provide users with a comprehensive set of tools to customize and manage their feed list effectively, catering to different preferences and workflows.

![1 - Setting](https://github.com/user-attachments/assets/05102051-bf25-400f-999c-bc3dac52a265)

| Enabled   | Disabled |
| ----- | --- |
| ![2 - B_2](https://github.com/user-attachments/assets/bc7644c3-17ab-4589-af70-0c8ae002a934) |  ![2 - B_1](https://github.com/user-attachments/assets/3dae78bf-2994-42bd-8c29-ad22b187b670) |
