### PR TITLE
Add new setting for disabled feeds: Custom color options

### DIFF
--- a/src/librssguard/core/feedsmodel.cpp
+++ b/src/librssguard/core/feedsmodel.cpp
@@ -564,6 +564,16 @@ QVariant FeedsModel::data(const QModelIndex& index, int role) const {
       }
     }
 
+    case Qt::ItemDataRole::ForegroundRole: {
+      RootItem* it = itemForIndex(index);
+
+      if (it->kind() == RootItem::Kind::Feed && qobject_cast<Feed*>(it)->isSwitchedOff()) {
+        return qApp->settings()->value(GROUP(CustomSkinColors), SETTING(CustomSkinColors::Enabled)).toBool()
+        ? qApp->skins()->colorForModel(SkinEnums::PaletteColors::FgDisabledFeed)
+        : QColor("#d1d1d1");
+      }
+    }
+
     case Qt::ItemDataRole::ToolTipRole:
       if (!qApp->settings()->value(GROUP(Feeds), SETTING(Feeds::EnableTooltipsFeedsMessages)).toBool()) {
         return QVariant();

--- a/src/librssguard/miscellaneous/skinfactory.cpp
+++ b/src/librssguard/miscellaneous/skinfactory.cpp
@@ -649,6 +649,9 @@ QString SkinEnums::palleteColorText(PaletteColors col) {
     case SkinEnums::PaletteColors::Allright:
       return QObject::tr("OK-ish color");
 
+    case SkinEnums::PaletteColors::FgDisabledFeed:
+      return QObject::tr("disabled items");
+
     default:
       return {};
   }

--- a/src/librssguard/miscellaneous/skinfactory.h
+++ b/src/librssguard/miscellaneous/skinfactory.h
@@ -41,7 +41,10 @@ class SkinEnums : public QObject {
       FgNewMessages = 32,
 
       // Foreground color of selected items with new articles.
-      FgSelectedNewMessages = 64
+      FgSelectedNewMessages = 64,
+
+      // Foreground color of disabled items.
+      FgDisabledFeed = 128
     };
 
     static QString palleteColorText(PaletteColors col);


### PR DESCRIPTION
A new color customization feature for disabled feeds has been implemented.
The "**Disabled Feeds**" color option is now accessible within the "**Customize predefined colors**" group.
The default display color for disabled feeds is gray.

> **NB :** This feature works seamlessly as a complementary addition to the other committed features, such as [Strikethrough](https://github.com/martinrotter/rssguard/pull/1651) and [Hide](https://github.com/martinrotter/rssguard/pull/1650) Together, these options provide users with a comprehensive set of tools to customize and manage their feed list effectively, catering to different preferences and workflows.

![1 - Setting](https://github.com/user-attachments/assets/fdf99166-9e48-42e7-9f74-52a3dc766a5c)

| Enabled   | Disabled |
| ----- | --- |
| ![2 - B_1](https://github.com/user-attachments/assets/00d137e3-5f24-4076-ac86-1320ad108d4e) | ![2 - B_2](https://github.com/user-attachments/assets/87a0b487-b470-42df-a3bd-aa835f5aa2a2) |