### PR TITLE
Use RTL direction for feed titles

### DIFF
--- a/src/librssguard/gui/settings/settingsfeedsmessages.cpp
+++ b/src/librssguard/gui/settings/settingsfeedsmessages.cpp
@@ -207,6 +207,7 @@ SettingsFeedsMessages::SettingsFeedsMessages(Settings* settings, QWidget* parent
           this,
           &SettingsFeedsMessages::dirtifySettings);
   connect(m_ui->m_checkShowTooltips, &QCheckBox::toggled, this, &SettingsFeedsMessages::dirtifySettings);
+  connect(m_ui->m_checkUseRtlForFeedTitles, &QCheckBox::toggled, this, &SettingsFeedsMessages::dirtifySettings);
   connect(m_ui->m_checkMultilineArticleList, &QCheckBox::toggled, this, &SettingsFeedsMessages::dirtifySettings);
   connect(m_ui->m_checkMultilineArticleList, &QCheckBox::toggled, this, &SettingsFeedsMessages::requireRestart);
 
@@ -352,6 +353,8 @@ void SettingsFeedsMessages::loadSettings() {
   m_ui->m_cmbCountsFeedList->setEditText(settings()->value(GROUP(Feeds), SETTING(Feeds::CountFormat)).toString());
   m_ui->m_checkShowTooltips
     ->setChecked(settings()->value(GROUP(Feeds), SETTING(Feeds::EnableTooltipsFeedsMessages)).toBool());
+  m_ui->m_checkUseRtlForFeedTitles
+    ->setChecked(settings()->value(GROUP(Feeds), SETTING(Feeds::UseRtlForFeedTitles)).toBool());
   m_ui->m_cmbIgnoreContentsChanges
     ->setChecked(settings()->value(GROUP(Messages), SETTING(Messages::IgnoreContentsChanges)).toBool());
   m_ui->m_checkMultilineArticleList
@@ -489,6 +492,7 @@ void SettingsFeedsMessages::saveSettings() {
   settings()->setValue(GROUP(Feeds), Feeds::FeedsUpdateStartupDelay, m_ui->m_spinStartupUpdateDelay->value());
   settings()->setValue(GROUP(Feeds), Feeds::CountFormat, m_ui->m_cmbCountsFeedList->currentText());
   settings()->setValue(GROUP(Feeds), Feeds::EnableTooltipsFeedsMessages, m_ui->m_checkShowTooltips->isChecked());
+  settings()->setValue(GROUP(Feeds), Feeds::UseRtlForFeedTitles, m_ui->m_checkUseRtlForFeedTitles->isChecked());
   settings()->setValue(GROUP(Messages), Messages::IgnoreContentsChanges, m_ui->m_cmbIgnoreContentsChanges->isChecked());
   settings()->setValue(GROUP(Messages), Messages::MultilineArticleList, m_ui->m_checkMultilineArticleList->isChecked());
   settings()->setValue(GROUP(Messages),

--- a/src/librssguard/gui/settings/settingsfeedsmessages.ui
+++ b/src/librssguard/gui/settings/settingsfeedsmessages.ui
@@ -266,6 +266,13 @@
          </property>
         </widget>
        </item>
+       <item row="10" column="0" colspan="2">
+        <widget class="QCheckBox" name="m_checkUseRtlForFeedTitles">
+         <property name="text">
+          <string>Use RTL direction for feed titles</string>
+         </property>
+        </widget>
+       </item>
        <item row="5" column="0" colspan="2">
         <widget class="QCheckBox" name="m_cbUpdateFeedListDuringFetching">
          <property name="text">
@@ -727,6 +734,7 @@
   <tabstop>m_cbUpdateFeedListDuringFetching</tabstop>
   <tabstop>m_cbListsRestrictedShortcuts</tabstop>
   <tabstop>m_checkShowTooltips</tabstop>
+  <tabstop>m_checkUseRtlForFeedTitles</tabstop>
   <tabstop>m_checkRemoveReadMessagesOnExit</tabstop>
   <tabstop>m_cbArticleViewerAlwaysVisible</tabstop>
   <tabstop>m_cmbIgnoreContentsChanges</tabstop>

--- a/src/librssguard/miscellaneous/settings.cpp
+++ b/src/librssguard/miscellaneous/settings.cpp
@@ -98,6 +98,9 @@ DVALUE(char*) Feeds::CountFormatDef = "(%unread)";
 DKEY Feeds::EnableTooltipsFeedsMessages = "show_tooltips";
 DVALUE(bool) Feeds::EnableTooltipsFeedsMessagesDef = true;
 
+DKEY Feeds::UseRtlForFeedTitles = "use_rtl_for_feed_titles";
+DVALUE(bool) Feeds::UseRtlForFeedTitlesDef = false;
+
 DKEY Feeds::PauseFeedFetching = "pause_feed_fetching";
 DVALUE(bool) Feeds::PauseFeedFetchingDef = false;
 

--- a/src/librssguard/miscellaneous/settings.h
+++ b/src/librssguard/miscellaneous/settings.h
@@ -94,6 +94,9 @@ namespace Feeds {
   KEY EnableTooltipsFeedsMessages;
   VALUE(bool) EnableTooltipsFeedsMessagesDef;
 
+  KEY UseRtlForFeedTitles;
+  VALUE(bool) UseRtlForFeedTitlesDef;
+
   KEY PauseFeedFetching;
   VALUE(bool) PauseFeedFetchingDef;
 

--- a/src/librssguard/services/abstract/feed.cpp
+++ b/src/librssguard/services/abstract/feed.cpp
@@ -78,7 +78,8 @@ QVariant Feed::data(int column, int role) const {
 
     case TEXT_DIRECTION_ROLE: {
       if (column == FDS_MODEL_TITLE_INDEX) {
-        return isRtl() ? Qt::LayoutDirection::RightToLeft : Qt::LayoutDirection::LayoutDirectionAuto;
+        const bool m_useRtlForFeedTitles = qApp->settings()->value(GROUP(Feeds), SETTING(Feeds::UseRtlForFeedTitles)).toBool();
+        return isRtl() && m_useRtlForFeedTitles ? Qt::LayoutDirection::RightToLeft : Qt::LayoutDirection::LayoutDirectionAuto;
       }
       else {
         return Qt::LayoutDirection::LayoutDirectionAuto;


### PR DESCRIPTION
Introduce an option to switch the direction of feed titles, enhancing readability and offering a more customizable user experience.

![1 - Setting](https://github.com/user-attachments/assets/fe36e6c0-5a6c-4a87-a675-b36d5108e96f)

| Enabled   | Disabled |
| ----- | --- |
| ![2 - B_2](https://github.com/user-attachments/assets/440fc286-409d-4066-80e1-f6d212eca9fb) | ![2 - B_1](https://github.com/user-attachments/assets/8cecc5d8-3f73-465d-8496-360fbf22834e) |
