### PR TITLE
Add git clone submodules on compile.md documentation

### DIFF
--- a/docs/source/contrib/compile.md
+++ b/docs/source/contrib/compile.md
@@ -5,6 +5,9 @@ RSS Guard is a `C++` application. All common build instructions can be found at 
 Here's a quick example of how to build it on Linux:
 
 ```bash
+# Clone the repo and all submodules
+git clone --recurse-submodules https://github.com/martinrotter/rssguard
+
 # Create a build directory
 mkdir build-dir
 


### PR DESCRIPTION
the option `--recurse-submodules` is not easy to find and it should be explicited that this repo is the specific submodules features. By default git clone doesn't gather submodules and it broke the compilation.

This documentation proposal is related to my journey on RSSGuard compilation here :  https://github.com/martinrotter/rssguard/issues/1697