### PR TITLE
Fix build error with the -Werror=return-type flag

### DIFF
--- a/src/librssguard-standard/src/standardfeed.cpp
+++ b/src/librssguard-standard/src/standardfeed.cpp
@@ -480,6 +480,9 @@ QString StandardFeed::getHttpDescription() const {
 
     case NetworkFactory::Http2Status::Disabled:
       return tr("disabled");
+
+    default:
+      return tr("unknown state");
   }
 }
 


### PR DESCRIPTION
This flag is automatically enabled in openSUSE Tumbleweed.