### PR TITLE
fix null char on rss feeds

### DIFF
--- a/src/librssguard-standard/src/parsers/atomparser.cpp
+++ b/src/librssguard-standard/src/parsers/atomparser.cpp
@@ -328,7 +328,9 @@ QPair<StandardFeed*, QList<IconLocation>> AtomParser::guessFeed(const QByteArray
   int error_line, error_column;
 
   if (!xml_document.setContent(xml_contents_encoded, true, &error_msg, &error_line, &error_column)) {
-    throw ApplicationException(QObject::tr("XML is not well-formed, %1").arg(error_msg));
+    throw ApplicationException(QObject::tr("XML is not well-formed, %1, line %2, column %3").arg(error_msg)
+                                                                        .arg(QString::number(error_line))
+                                                                        .arg(QString::number(error_column)));
   }
 
   QDomElement root_element = xml_document.documentElement();

--- a/src/librssguard-standard/src/parsers/rdfparser.cpp
+++ b/src/librssguard-standard/src/parsers/rdfparser.cpp
@@ -203,7 +203,9 @@ QPair<StandardFeed*, QList<IconLocation>> RdfParser::guessFeed(const QByteArray&
   int error_line, error_column;
 
   if (!xml_document.setContent(xml_contents_encoded, true, &error_msg, &error_line, &error_column)) {
-    throw ApplicationException(QObject::tr("XML is not well-formed, %1").arg(error_msg));
+    throw ApplicationException(QObject::tr("XML is not well-formed, %1, line %2, column %3").arg(error_msg)
+                                                                         .arg(QString::number(error_line))
+                                                                          .arg(QString::number(error_column)));
   }
 
   QDomElement root_element = xml_document.documentElement();

--- a/src/librssguard-standard/src/parsers/rssparser.cpp
+++ b/src/librssguard-standard/src/parsers/rssparser.cpp
@@ -197,6 +197,7 @@ QPair<StandardFeed*, QList<IconLocation>> RssParser::guessFeed(const QByteArray&
   // NOTE: Some XMLs have whitespace before XML declaration, erase it.
   xml_contents_encoded = xml_contents_encoded.trimmed();
   xml_contents_encoded = xml_contents_encoded.remove(QChar::Null);
+  xml_contents_encoded = xml_contents_encoded.replace(QChar(0x000B), QChar(' '));
 
   // Feed XML was obtained, guess it now.
   DomDocument xml_document;

--- a/src/librssguard-standard/src/parsers/rssparser.cpp
+++ b/src/librssguard-standard/src/parsers/rssparser.cpp
@@ -196,6 +196,7 @@ QPair<StandardFeed*, QList<IconLocation>> RssParser::guessFeed(const QByteArray&
 
   // NOTE: Some XMLs have whitespace before XML declaration, erase it.
   xml_contents_encoded = xml_contents_encoded.trimmed();
+  xml_contents_encoded = xml_contents_encoded.remove(QChar::Null);
 
   // Feed XML was obtained, guess it now.
   DomDocument xml_document;

--- a/src/librssguard-standard/src/parsers/rssparser.cpp
+++ b/src/librssguard-standard/src/parsers/rssparser.cpp
@@ -203,7 +203,9 @@ QPair<StandardFeed*, QList<IconLocation>> RssParser::guessFeed(const QByteArray&
   int error_line, error_column;
 
   if (!xml_document.setContent(xml_contents_encoded, true, &error_msg, &error_line, &error_column)) {
-    throw ApplicationException(QObject::tr("XML is not well-formed, %1").arg(error_msg));
+    throw ApplicationException(QObject::tr("XML is not well-formed, %1, line %2, column %3").arg(error_msg)
+                                                                                .arg(QString::number(error_line))
+                                                                                .arg(QString::number(error_column)));
   }
 
   QDomElement root_element = xml_document.documentElement();

--- a/src/librssguard-standard/src/standardserviceroot.cpp
+++ b/src/librssguard-standard/src/standardserviceroot.cpp
@@ -368,6 +368,9 @@ QList<Message> StandardServiceRoot::obtainNewMessages(Feed* feed,
     formatted_feed_contents = codec->toUnicode(feed_contents);
   }
 
+  // we remove null char just in case
+  formatted_feed_contents = formatted_feed_contents.remove(QChar::Null);
+
   // Feed data are downloaded and encoded.
   // Parse data and obtain messages.
   QList<Message> messages;
@@ -409,6 +412,7 @@ QList<Message> StandardServiceRoot::obtainNewMessages(Feed* feed,
   if (!f->dateTimeFormat().isEmpty()) {
     parser->setDateTimeFormat(f->dateTimeFormat());
   }
+
 
   parser->setDontUseRawXmlSaving(f->dontUseRawXmlSaving());
   messages = parser->messages();

--- a/src/librssguard-standard/src/standardserviceroot.cpp
+++ b/src/librssguard-standard/src/standardserviceroot.cpp
@@ -370,6 +370,7 @@ QList<Message> StandardServiceRoot::obtainNewMessages(Feed* feed,
 
   // we remove null char just in case
   formatted_feed_contents = formatted_feed_contents.remove(QChar::Null);
+  formatted_feed_contents = formatted_feed_contents.replace(QChar(0x000B), QChar(' '));
 
   // Feed data are downloaded and encoded.
   // Parse data and obtain messages.


### PR DESCRIPTION
Hi, 

I notice on some of my feeds than the feed work fine, but RSS Guard is unable to load it (reference on #1777 ).
After some debug and troubleshoot, I finally found that when null char are present into the feed content, the XML parsing crash.

I've developed a fix, but I'm not sure if it's the good way to fix it.

Considering the problem origin is the presence of null char, should they need to be removed directly on http response ? 

