### PR TITLE
Update docs with instructions for dealing with MacOS crashs and updated compiling instructions for RSS Guard 5.x.x

### DIFF
--- a/docs/source/contrib/compile.md
+++ b/docs/source/contrib/compile.md
@@ -4,10 +4,12 @@ RSS Guard is a `C++` application. All common build instructions can be found at 
 
 ```{warning}
 Note that on modern MacOS machines you will experience crashs when launching RSS Guard, and you will have to self-sign the application via `codesign` utility to make it run.
+```
 
-You can generally solve this this by executing this command in a terminal relative to the .app's installed location. 
+You can generally solve this this by executing this command in a terminal relative to the .app's installed location.
+
 ```bash
-codesign --deep -fs - "RSS Guard.app"
+sudo codesign --deep -fs - "RSS Guard.app"
 ```
 
 Here's a quick example of how to build it on Linux:
@@ -20,7 +22,7 @@ cd rssguard
 mkdir rssguard-build
 cd rssguard-build
 
-# Configure the project to build using Qt 6, and disable built-in web browser support
+# Configure the project to build using Qt 6.
 cmake .. --warn-uninitialized -G Ninja -DFORCE_BUNDLE_ICONS="ON" -DCMAKE_VERBOSE_MAKEFILE="ON" -DREVISION_FROM_GIT="ON" -DBUILD_WITH_QT6="ON" -DENABLE_COMPRESSED_SITEMAP="ON" -DENABLE_MEDIAPLAYER_LIBMPV="ON" -DENABLE_MEDIAPLAYER_QTMULTIMEDIA="OFF"
 
 # Compile it
@@ -32,3 +34,4 @@ cmake --build .
 # (Optional) Install RSS Guard system-wide
 sudo cmake --install . --prefix /usr --verbose
 ```
+


### PR DESCRIPTION
Hey I was trying to compile this on my fedora asahi machine and noticed that there wasn't updated instructions for the latest git releases. This is my attempt to help with this.

I think it would make sense to also list the libraries needed to properly build the package, but I'm not entirely sure what's needed officially library wise.
 I see on my fedora 41 release machine probably needed the following packages to build properly.

`litehtml litehtml-devel sqlite sqlite-devel mpv-devel mpv mpv-libs  mpvqt-devel  mpvqt qt6-qt5compat-devel qt6-qt5compat phonon-qt6-devel  phonon-qt6 qt6-qtmultimedia  qt6-qtmultimedia-devel qt6-qt3d-devel  qt6-qt3d gstreamer1-plugins-good-qt6  accounts-qml-module-qt6 qt6-qttools-static qt6-qttools-common qt6-qttools qt6-linguist qt6-qtbase-devel qt6-qtbase`

And per the arch build script these packages:
`appstream base-devel cmake curl gcc-libs git glibc gtk3 libheif libglvnd libxcb libxcursor libxi libxkbcommon libxkbcommon-x11 libxrandr libxtst make mariadb-clients mpv ninja pipewire-audio pulseaudio pulseaudio-alsa qt5-base qt5-declarative qt5-imageformats qt5-multimedia qt5-tools qt5-wayland qt5-svg qt6-5compat qt6-base qt6-declarative qt6-imageformats qt6-multimedia qt6-tools qt6-wayland qt6-svg qt6ct sqlite wget xorg-server-xvfb zsync`

But like perhaps there's too much maintenance overhead to list packages needed as they get renamed and change. :shrug: 

