### PR TITLE
simplify AppImage deployment

### DIFF
--- a/resources/scripts/github-actions/build-linux-mac.sh
+++ b/resources/scripts/github-actions/build-linux-mac.sh
@@ -90,25 +90,18 @@ if [ $is_linux = true ]; then
   echo 'Validating AppStream metadata...'
   appstreamcli validate "$prefix/share/metainfo/$app_id.metainfo.xml"
   
-  URUNTIME="https://raw.githubusercontent.com/pkgforge-dev/Anylinux-AppImages/refs/heads/main/useful-tools/uruntime2appimage.sh"
   SHARUN="https://raw.githubusercontent.com/pkgforge-dev/Anylinux-AppImages/refs/heads/main/useful-tools/quick-sharun.sh"
   
   export DESKTOP=$prefix/share/applications/io.github.martinrotter.rssguard.desktop
   export DEPLOY_OPENGL=1
+  export OUTPUT_APPIMAGE=1
 
   echo "Desktop file: $DESKTOP"
 
   wget --retry-connrefused --tries=30 "$SHARUN" -O ./quick-sharun
   chmod +x ./quick-sharun
 
-  wget --retry-connrefused --tries=30 "$URUNTIME" -O ./uruntime2appimage
-  chmod +x ./uruntime2appimage
-
-  #mkdir -p "./AppDir/shared/lib/qt6/plugins/sqldrivers"
-  #cp -v -R "/usr/lib/qt6/plugins/sqldrivers" "./AppDir/shared/lib/qt6/plugins/"
-
   ./quick-sharun /usr/bin/rssguard /usr/lib/rssguard/*
-  ./uruntime2appimage
 
   set -- *.AppImage
 else


### PR DESCRIPTION
Qt webengine and sqldrivers deployment were [added at the same time](https://github.com/pkgforge-dev/Anylinux-AppImages/commit/3e1bd5414d7a932f7f37310d30c828b9df4e126b), was there a bug that `sqldrivers` wasn't being added? 

The determination to add sqldrivers is done when we detect `libQtXSql.so` so let me know if this needs to improve. 

There is no more need to be downloading `uruntime2appimage`, this gets done in `quick-sharun` by setting the env variable `OUTPUT_APPIMAGE`, this assumes that no more changes will be needed after deploying. If in the future extra changes are needed then you can just run remove the var and run `./quick-sharun --make-appimage` the second time. 

Also the name of the final AppImage can be changed by setting the `OUTNAME` variable, right now it will just make a guess based off the name found in the desktop entry and the `VERSION` variable if set. 