### PR TITLE
remove `qt6-wayland`

### DIFF
--- a/resources/scripts/github-actions/prepare-linux.sh
+++ b/resources/scripts/github-actions/prepare-linux.sh
@@ -48,7 +48,6 @@ pacman -Syu --noconfirm  \
     qt6-imageformats     \
     qt6-multimedia       \
     qt6-tools            \
-    qt6-wayland          \
     qt6-svg              \
     qt6ct                \
     sqlite               \


### PR DESCRIPTION
Hasn't been needed for wayland clients in Qt for while: https://archlinux.org/todo/qt6-wayland-dependency-cleanup/

I don't think this is the case for `qt5-wayland`, so that one was left in place.

