### PR TITLE
Use file globbing for AppImage deployment

### DIFF
--- a/resources/scripts/github-actions/build-linux-mac.sh
+++ b/resources/scripts/github-actions/build-linux-mac.sh
@@ -19,7 +19,7 @@ if [[ "$os" == *"ubuntu"* ]]; then
   is_linux=true
   os_id="linux64"
   image_suffix="AppImage"
-  prefix="/usr"
+  prefix="/usr/local/rssguard"
 
   libmpv="ON"
   qtmultimedia="OFF"
@@ -102,7 +102,7 @@ if [ $is_linux = true ]; then
   wget --retry-connrefused --tries=30 "$SHARUN" -O ./quick-sharun
   chmod +x ./quick-sharun
 
-  ./quick-sharun /usr/bin/rssguard /usr/lib/rssguard/*
+  ./quick-sharun "$prefix"/*/*
 
   set -- *.AppImage
 else


### PR DESCRIPTION
This updates the Linux build script used in CI to set the install prefix to `/usr/local/rssguard`, making the AppImage deployment easier later by using globbing to include all files installed to that directory.

This approach allows us to avoid manually including files that would otherwise be missing, such as the `rssguard-article-extractor` Go binary.