### PR TITLE
Don't call `QCoreApplication::processEvents()` on shutdown

### DIFF
--- a/src/librssguard/miscellaneous/application.cpp
+++ b/src/librssguard/miscellaneous/application.cpp
@@ -750,7 +750,6 @@ void Application::onAboutToQuit() {
   // Make sure that we obtain close lock BEFORE even trying to quit the application.
   const bool locked_safely = feedUpdateLock()->tryLock(4 * CLOSE_LOCK_TIMEOUT);
 
-  QCoreApplication::processEvents();
   qDebugNN << LOGSEC_CORE << "Cleaning up resources and saving application state.";
 
   if (locked_safely) {


### PR DESCRIPTION
Although this doesn't seem to cause issues in the `master` branch, it has been observed that [v4.8.6 crashes](https://github.com/flathub/io.github.martinrotter.rssguard/issues/195) with a `SEGFAULT` upon exiting if the following criteria are met: Qt 6.10 + non-lite build + system tray feature disabled.