### PR TITLE
chore: Add Dependabot for updating GitHub Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,4 +9,4 @@ updates:
     directory: "/"
     schedule:
       interval: weekly
-    open-pull-requests-limit: 99
+    open-pull-requests-limit: 10


### PR DESCRIPTION
Noticed some of the GitHub Actions were a few major versions behind. Instead of a on-time bump, this sets up Dependabot to open PRs when new major versions are released.