### PR TITLE
ci: Use Python 3.13 for aqtinstall

### DIFF
--- a/.github/workflows/rssguard.yml
+++ b/.github/workflows/rssguard.yml
@@ -86,6 +86,7 @@ jobs:
     runs-on: "${{ matrix.os }}"
     container: ${{ matrix.cont }}
     strategy:
+      fail-fast: false
       matrix:
         os: [windows-2022, ubuntu-24.04, macos-15]
         use_qt5: ["ON", "OFF"]
@@ -181,4 +182,5 @@ jobs:
           artifactErrorsFailBuild: true
           artifacts: artifacts/*/*
           draft: true
+
 


### PR DESCRIPTION
Looks like https://github.com/miurahr/aqtinstall requires at least Python 3.10 now, but recommends 3.13.
Since I wanted to see if all the jobs passed, even if one failed, I turned off `fail-fast` on the build matrix.