### PR TITLE
Linux: Add repository link to metadata

### DIFF
--- a/resources/desktop/rssguard.metainfo.xml.in
+++ b/resources/desktop/rssguard.metainfo.xml.in
@@ -47,6 +47,7 @@
     </screenshot>
   </screenshots>
   <url type="homepage">https://github.com/martinrotter/rssguard</url>
+  <url type="vcs-browser">https://github.com/martinrotter/rssguard</url>
   <url type="help">https://rssguard.readthedocs.io</url>
   <url type="bugtracker">https://github.com/martinrotter/rssguard/issues</url>
   <url type="donation">https://github.com/sponsors/martinrotter</url>


### PR DESCRIPTION
This is to fix a new linter warning from Flathub:

https://docs.flathub.org/docs/for-app-authors/linter#appstream-missing-vcs-browser-url