### PR TITLE
Unbreak AppImage deployment

### DIFF
--- a/resources/scripts/github-actions/build-linux-mac.sh
+++ b/resources/scripts/github-actions/build-linux-mac.sh
@@ -103,7 +103,7 @@ if [ $is_linux = true ]; then
   wget --retry-connrefused --tries=30 "$SHARUN" -O ./quick-sharun
   chmod +x ./quick-sharun
 
-  ./quick-sharun /usr/bin/rssguard /usr/lib/rssguard/*
+  ./quick-sharun /usr/*/rssguard*
 
   set -- *.AppImage
 else


### PR DESCRIPTION
[A recent change to the AppImage deployment tool](https://redirect.github.com/pkgforge-dev/Anylinux-AppImages/issues/228) prevents the solution I added in https://github.com/martinrotter/rssguard/commit/0029299a0b2487a59bce266ced0ad6b1ca815795.

This PR reverts that change, which essentially just means setting the install path back to `/usr` instead of `/usr/local/rssguard`.

However, there's still the need to include the Go article extractor binary (`/usr/bin/rssguard-article-extractor`), so this also tweaks the AppImage globbing pattern to include it.

Lastly, this sets the `ICON` environment variable to silence a warning from the AppImage deployment tool.