### PR TITLE
Linux: Update icon install path

### DIFF
--- a/src/rssguard/CMakeLists.txt
+++ b/src/rssguard/CMakeLists.txt
@@ -64,7 +64,7 @@ elseif((MINGW AND BUILD_MSYS2) OR (UNIX AND NOT APPLE))
       DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/metainfo
     )
     install(FILES ${CMAKE_SOURCE_DIR}/resources/graphics/${CMAKE_PROJECT_NAME}.png
-      DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/icons/hicolor/256x256/apps
+      DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/icons/hicolor/512x512/apps
       RENAME ${APP_REVERSE_NAME}.png
     )
   endif()


### PR DESCRIPTION
Commit 900e50eb3ce32b8f77a2493c33dffdff0e3d5c15 replaced a 256x256 icon by a 512x512 one (`resources/graphics/rssguard.png`), so this change updates the install path of the new icon accordingly.