### PR TITLE
Hide "Check for updates" menu option when `NO_UPDATE_CHECK=ON`

### DIFF
--- a/src/librssguard/gui/dialogs/formmain.cpp
+++ b/src/librssguard/gui/dialogs/formmain.cpp
@@ -69,6 +69,10 @@ FormMain::FormMain(QWidget* parent, Qt::WindowFlags f)
   main_menu->addMenu(m_ui->m_menuTools);
   main_menu->addMenu(m_ui->m_menuHelp);
 
+#if defined(NO_UPDATE_CHECK)
+  m_ui->m_actionCheckForUpdates->setVisible(false);
+#endif
+
   QToolButton* btn_main_menu = new QToolButton(this);
 
   btn_main_menu->setToolTip(tr("Open main menu"));


### PR DESCRIPTION
It doesn't make sense to expose this menu option if the app was built with `-DNO_UPDATE_CHECK=ON`.