### PR TITLE
Darker highlight shade and white highlight text

### DIFF
--- a/resources/skins/minimal-dark/metadata.xml
+++ b/resources/skins/minimal-dark/metadata.xml
@@ -28,14 +28,14 @@
       <color role="Mid">#292c2e</color>
       <color role="Shadow">#292c2e</color>
       <color role="Light">#56575c</color>
-      <color role="Highlight">#add8e6</color>
+      <color role="Highlight">#617996</color>
 
       <color role="Window">#303030</color>
       <color role="Button">#2C2D30</color>
 
       <color role="Text">#D9D9D9</color>
       <color role="BrightText">#2F3134</color>
-      <color role="HighlightedText">#000000</color>
+      <color role="HighlightedText">#ffffff</color>
       <color role="PlaceholderText">#A7A7A7</color>
       <color role="ToolTipText">#D8D8D8</color>
       <color role="ButtonText">#E7E7E7</color>


### PR DESCRIPTION
Just a tad bit darker for nicer visibility than the example at: https://github.com/martinrotter/rssguard/issues/2054#issuecomment-3977361065

The white highlight text looks better with the darker highlight shade, also goes in line with more "universal" dark mode looks of browsers, etc

Sort of a rollback because it's basically how dark mode looked in 4.x :D