### PR TITLE
Linux: Adjust app id based on build variant

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -170,6 +170,7 @@ if (WEB_ARTICLE_VIEWER_WEBENGINE)
 
   message(STATUS "We will use QtWebEngine-based web viewer.")
 else()
+  set(APP_REVERSE_NAME "io.github.martinrotter.rssguardlite")
   add_compile_definitions(WEB_ARTICLE_VIEWER_TEXTBROWSER)
 
   message(STATUS "We will use QTextBrowser-based web viewer.")

--- a/resources/desktop/CMakeLists.txt
+++ b/resources/desktop/CMakeLists.txt
@@ -1,5 +1,10 @@
-set(APPDATA_NAME "${APP_NAME}")
-set(APPDATA_SUMMARY "Simple, yet powerful news feed reader")
+if(WEB_ARTICLE_VIEWER_WEBENGINE)
+  set(APPDATA_NAME "${APP_NAME}")
+  set(APPDATA_SUMMARY "Simple, yet powerful news feed reader")
+else()
+  set(APPDATA_NAME "${APP_NAME} Lite")
+  set(APPDATA_SUMMARY "Simple, yet powerful news feed reader (without web browser)")
+endif()
 
 configure_file(
   rssguard.desktop.in

--- a/resources/scripts/github-actions/build-linux-mac.sh
+++ b/resources/scripts/github-actions/build-linux-mac.sh
@@ -30,7 +30,6 @@ fi
 
   libmpv="ON"
   qtmultimedia="OFF"
-  app_id="io.github.martinrotter.rssguard"
 else
   echo "We are building for macOS."
   is_linux=false
@@ -50,8 +49,10 @@ else
 fi
 
 if [[ "$webengine_viewer" == "ON" ]]; then
+  app_id="io.github.martinrotter.rssguard"
   variant_id="web"
 else
+  app_id="io.github.martinrotter.rssguardlite"
   variant_id="text"
 fi
 


### PR DESCRIPTION
If it's the "standard" build (WebEngineViewer), then the app id is set to `io.github.martinrotter.rssguard`.

If it's the "text" build (TextBrowserViewer), then the app id is set to `io.github.martinrotter.rssguardlite`, plus the app name in the metainfo file is set to "RSS Guard Lite".

I know you dislike the "Lite" name, but it will only be shown in Linux app store front-ends (such as Flathub's website), so hopefully you agree it's not *that* meaningful.