### PR TITLE
Linux: Mention XMPP PubSub and Gemini Protocol support in metainfo

### DIFF
--- a/resources/desktop/rssguard.metainfo.xml.in
+++ b/resources/desktop/rssguard.metainfo.xml.in
@@ -31,6 +31,8 @@
       <li>Google Reader API (Bazqux, FreshRSS, Inoreader, Miniflux, Reedah, The Old Reader, etc.)</li>
       <li>Next Cloud News</li>
       <li>Tiny Tiny RSS</li>
+      <li>XMPP PubSub</li>
+      <li>Gemini Protocol</li>
     </ul>
   </description>
   <launchable type="desktop-id">@APP_REVERSE_NAME@.desktop</launchable>
@@ -61,6 +63,9 @@
     <keyword translate="no">Reedah</keyword>
     <keyword translate="no">The Old Reader</keyword>
     <keyword translate="no">Tiny Tiny RSS</keyword>
+    <keyword translate="no">Gemini</keyword>
+    <keyword translate="no">XMPP</keyword>
+    <keyword translate="no">PubSub</keyword>
   </keywords>
   <content_rating type="oars-1.1" />
   <releases>


### PR DESCRIPTION
I'm not familiar with them, so let me know if these are worded correctly.

Thanks!